### PR TITLE
CICD : 도커 캐시 사용해서 빌드 최적화

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -30,22 +30,14 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build
 
-      - name: Build Docker Image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          dockerfile: Dockerfile
-          push: false
-          tags: ${{secrets.DOCKER_USERNAME}}/zerozero:latest
-
       - name: Login to Docker
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_ACCESS_TOKEN}}
 
-      - name: Push to Docker
-        uses: docker/build-push-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
           context: .
           dockerfile: Dockerfile

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,8 +3,6 @@ name: Zerozero Server CICD
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,13 +43,8 @@ jobs:
           dockerfile: Dockerfile
           push: true
           tags: ${{secrets.DOCKER_USERNAME}}/zerozero:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache     
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy
         uses: appleboy/ssh-action@master

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,8 +43,13 @@ jobs:
           dockerfile: Dockerfile
           push: true
           tags: ${{secrets.DOCKER_USERNAME}}/zerozero:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache     
 
       - name: Deploy
         uses: appleboy/ssh-action@master

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,8 @@ name: Zerozero Server CICD
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -48,6 +51,8 @@ jobs:
           dockerfile: Dockerfile
           push: true
           tags: ${{secrets.DOCKER_USERNAME}}/zerozero:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy
         uses: appleboy/ssh-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM openjdk:17-jdk-alpine
 
 COPY build/libs/*.jar zerozero.jar
 


### PR DESCRIPTION
## 변경사항

### Github Actions Cache 적용 실패
- GithubActions Cache를 적용했으나 기존과 다른게 없다.

### Docker Image 빌드, 푸시 과정 통합
- 기존에는 Docker Image 빌드, 푸시가 나눠져 있었다.
- 이를 합치면 시간을 줄일 수 있을 거 같아 통합했다.

### Alpine 기반 JDK 설치
- Alpine 기반 JDK를 설치함으로써 Docker Image를 줄일 수 있다.

#43 