### PR TITLE
REFACTOR: (#53) ddl-auto 대신 DDL을 직접 작성한다

### DIFF
--- a/mysql/0_refresh_token.sql
+++ b/mysql/0_refresh_token.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS refresh_token
+(
+    id                  BINARY(16)                NOT NULL            COMMENT 'ID',
+    refresh_token       VARCHAR(255)              NOT NULL            COMMENT '리프레시 토큰',
+    user_id             BINARY(16)                NULL                COMMENT '사용자 ID',
+    created_at          DATETIME                  NULL                COMMENT '생성일시',
+    updated_at          DATETIME                  NULL                COMMENT '수정일시',
+    deleted             BOOLEAN                   NOT NULL DEFAULT 0  COMMENT '삭제여부 0:미삭제, 1:삭제',
+    PRIMARY KEY (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT '리프레시 토큰';

--- a/mysql/0_review.sql
+++ b/mysql/0_review.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS review
+(
+    id            BINARY(16)                NOT NULL            COMMENT 'ID',
+    zero_drinks   JSON                      NOT NULL            COMMENT '제로음료 종류',
+    content       VARCHAR(255)              NOT NULL            COMMENT '판매점 종류',
+    user_id       BINARY(16)                NULL                COMMENT '사용자 ID',
+    store_id      BINARY(16)                NULL                COMMENT '판매점 ID',
+    created_at    DATETIME                  NULL                COMMENT '생성일시',
+    updated_at    DATETIME                  NULL                COMMENT '수정일시',
+    deleted       BOOLEAN                   NOT NULL DEFAULT 0  COMMENT '삭제여부 0:미삭제, 1:삭제',
+    PRIMARY KEY (id),
+    INDEX `review_index_user_id` (user_id),
+    INDEX `review_index_store_id` (store_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT '리뷰';

--- a/mysql/0_review_like.sql
+++ b/mysql/0_review_like.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS review_like
+(
+    id            BINARY(16)                NOT NULL            COMMENT 'ID',
+    review_id     BINARY(16)                NULL                COMMENT '리뷰 ID',
+    user_id       BINARY(16)                NULL                COMMENT '사용자 ID',
+    created_at    DATETIME                  NULL                COMMENT '생성일시',
+    updated_at    DATETIME                  NULL                COMMENT '수정일시',
+    deleted       BOOLEAN                   NOT NULL DEFAULT 0  COMMENT '삭제여부 0:미삭제, 1:삭제',
+    PRIMARY KEY (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT '리뷰 좋아요';

--- a/mysql/0_store.sql
+++ b/mysql/0_store.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS store
+(
+    id            BINARY(16)                NOT NULL            COMMENT 'ID',
+    name          VARCHAR(255)              NOT NULL            COMMENT '판매점 이름',
+    category      VARCHAR(255)              NOT NULL            COMMENT '판매점 종류',
+    address       VARCHAR(255)              NULL                COMMENT '판매점 주소',
+    roadAddress   VARCHAR(255)              NULL                COMMENT '도로명 주소',
+    mapx          INT                       NOT NULL            COMMENT '주소 - x좌표',
+    mapy          INT                       NOT NULL            COMMENT '주소 - y좌표',
+    status        BOOLEAN                   NULL                COMMENT '판매 여부 0:미판매, 1:판매',
+    images        JSON                      NULL                COMMENT '이미지 목록',
+    user_id       BINARY(16)                NULL                COMMENT '사용자 ID',
+    created_at    DATETIME                  NULL                COMMENT '생성일시',
+    updated_at    DATETIME                  NULL                COMMENT '수정일시',
+    deleted       BOOLEAN                   NOT NULL DEFAULT 0  COMMENT '삭제여부 0:미삭제, 1:삭제',
+    PRIMARY KEY (id),
+    INDEX `store_index_name` (name),
+    INDEX `store_index_category` (category),
+    INDEX `store_index_address` (address),
+    INDEX `store_index_roadAddress` (roadAddress),
+    INDEX `store_index_mapx` (mapx),
+    INDEX `store_index_mapy` (mapy),
+    INDEX `store_index_status` (status),
+    INDEX `store_index_user_id` (user_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT '판매점';

--- a/mysql/0_user.sql
+++ b/mysql/0_user.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS user
+(
+    id            BINARY(16)                NOT NULL            COMMENT 'ID',
+    nickname      VARCHAR(255)              NOT NULL            COMMENT '닉네임',
+    email         VARCHAR(255)              NOT NULL            COMMENT '이메일',
+    password      VARCHAR(255)              NOT NULL            COMMENT '비밀번호',
+    profile_image VARCHAR(255)              NULL                COMMENT '프로필 사진',
+    role          ENUM ('USER', 'ADMIN')    NOT NULL            COMMENT '권한',
+    created_at    DATETIME                  NULL                COMMENT '생성일시',
+    updated_at    DATETIME                  NULL                COMMENT '수정일시',
+    deleted       BOOLEAN                   NOT NULL DEFAULT 0  COMMENT '삭제여부 0:미삭제, 1:삭제',
+    PRIMARY KEY (id),
+    INDEX `user_index_nickname` (nickname)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT '사용자';

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,8 +8,6 @@ spring:
     username: root
     password:
   jpa:
-    hibernate:
-      ddl-auto: update
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,8 +5,6 @@ spring:
     username: ENC(hIB+Lwmf5YEV6Fxhyf83uEKJCwmtwCto)
     password: ENC(mAQQhW6j4EsXca6HtrbdHBsqo+vKqmp5)
   jpa:
-    hibernate:
-      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
기존 테이블과 변경점은 다음과 같습니다.

- id : Long 타입에서 UUID로 변경
- deleted : 속성 추가, 논리적 삭제를 위해 추가
- zero_drinks : 기존에는 테이블 생성을 통해 연결하였지만 단순 정보 값이므로 JSON으로 타입 변경
- store 
  - selling -> status로 이름 변경 (프론트 대응 필요)
  - imageUrl -> images로 이름 변경 (프론트 대응 필요)

또한 hibernate ddl-auto로 테이블 자동 생성 제거하였습니다.