### PR TITLE
FEAT: (#59) 기존 회원가입 로직에 존재하던 이메일 중복 검증을 API로 분리한다

### DIFF
--- a/src/main/java/com/zerozero/auth/application/EmailDuplicationCheckUseCase.java
+++ b/src/main/java/com/zerozero/auth/application/EmailDuplicationCheckUseCase.java
@@ -1,0 +1,99 @@
+package com.zerozero.auth.application;
+
+import com.zerozero.auth.application.EmailDuplicationCheckUseCase.EmailDuplicationCheckRequest;
+import com.zerozero.auth.application.EmailDuplicationCheckUseCase.EmailDuplicationCheckResponse;
+import com.zerozero.core.application.BaseRequest;
+import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.application.BaseUseCase;
+import com.zerozero.core.domain.infra.repository.UserJPARepository;
+import com.zerozero.core.exception.DomainException;
+import com.zerozero.core.exception.error.BaseErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailDuplicationCheckUseCase implements BaseUseCase<EmailDuplicationCheckRequest, EmailDuplicationCheckResponse> {
+
+  private final UserJPARepository userJPARepository;
+
+  @Override
+  public EmailDuplicationCheckResponse execute(EmailDuplicationCheckRequest request) {
+    if (request == null || !request.isValid()) {
+      log.error("[EmailDuplicationCheckUseCase] Email is invalid");
+      return EmailDuplicationCheckResponse.builder().success(false)
+          .errorCode(EmailDuplicationCheckErrorCode.NOT_EXIST_EMAIL_CONDITION)
+          .build();
+    }
+    Boolean isUserEmailDuplicated = userJPARepository.existsByEmail(request.getEmail());
+    if (isUserEmailDuplicated == null) {
+      log.error("[EmailDuplicationCheckUseCase] Failed to check email duplication");
+      return EmailDuplicationCheckResponse.builder().success(false)
+          .errorCode(EmailDuplicationCheckErrorCode.FAILED_EMAIL_DUPLICATION_CHECK)
+          .build();
+    }
+    if (isUserEmailDuplicated) {
+      log.error("[EmailDuplicationCheckUseCase] Email already exists");
+      return EmailDuplicationCheckResponse.builder().success(false)
+          .errorCode(EmailDuplicationCheckErrorCode.EMAIL_ALREADY_EXISTS)
+          .build();
+    }
+    return EmailDuplicationCheckResponse.builder().build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum EmailDuplicationCheckErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_EMAIL_CONDITION(HttpStatus.BAD_REQUEST, "이메일 양식이 올바르지 않습니다."),
+    FAILED_EMAIL_DUPLICATION_CHECK(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 중복 검증에 실패하였습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이메일이 이미 존재합니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class EmailDuplicationCheckResponse extends BaseResponse<EmailDuplicationCheckErrorCode> {
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class EmailDuplicationCheckRequest implements BaseRequest {
+
+    private String email;
+
+    @Override
+    public boolean isValid() {
+      return email != null && !email.isEmpty();
+    }
+  }
+
+}

--- a/src/main/java/com/zerozero/auth/presentation/EmailDuplicationCheckController.java
+++ b/src/main/java/com/zerozero/auth/presentation/EmailDuplicationCheckController.java
@@ -1,0 +1,63 @@
+package com.zerozero.auth.presentation;
+
+import com.zerozero.auth.application.EmailDuplicationCheckUseCase;
+import com.zerozero.auth.application.EmailDuplicationCheckUseCase.EmailDuplicationCheckRequest;
+import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.exception.error.GlobalErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "User", description = "사용자")
+public class EmailDuplicationCheckController {
+
+  private final EmailDuplicationCheckUseCase emailDuplicationCheckUseCase;
+
+  @Operation(
+      summary = "이메일 중복 검증 API",
+      description = "사용자 이메일이 중복인지 검증합니다.",
+      operationId = "/email/duplicate-check"
+  )
+  @GetMapping("/email/duplicate-check")
+  public ResponseEntity<EmailDuplicationCheckResponse> emailDuplicationCheck(
+      @Schema(description = "이메일", example = "zerozero@drink.com") @Valid @Email String email) {
+    EmailDuplicationCheckUseCase.EmailDuplicationCheckResponse emailDuplicationCheckResponse = emailDuplicationCheckUseCase.execute(
+        EmailDuplicationCheckRequest.builder()
+            .email(email)
+            .build());
+    if (emailDuplicationCheckResponse == null || !emailDuplicationCheckResponse.isSuccess()) {
+      Optional.ofNullable(emailDuplicationCheckResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+    return ResponseEntity.ok().build();
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @Schema(description = "이메일 중복 검증 응답")
+  public static class EmailDuplicationCheckResponse extends BaseResponse<GlobalErrorCode> {
+  }
+}


### PR DESCRIPTION
기존 회원가입 로직에 존재하던 이메일 중복 검증을 API로 분리하는 작업으로

중복일 시 에러 응답 반환하게 하였고,

중복 아니면 200 응답 코드 반환하게 하였습니다.