### PR TITLE
FEAT: (#67) 스웨거에서 에러 코드를 조회할 수 있다

### DIFF
--- a/src/main/java/com/zerozero/auth/presentation/EmailDuplicationCheckController.java
+++ b/src/main/java/com/zerozero/auth/presentation/EmailDuplicationCheckController.java
@@ -1,7 +1,9 @@
 package com.zerozero.auth.presentation;
 
 import com.zerozero.auth.application.EmailDuplicationCheckUseCase;
+import com.zerozero.auth.application.EmailDuplicationCheckUseCase.EmailDuplicationCheckErrorCode;
 import com.zerozero.auth.application.EmailDuplicationCheckUseCase.EmailDuplicationCheckRequest;
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,6 +35,7 @@ public class EmailDuplicationCheckController {
       description = "사용자 이메일이 중복인지 검증합니다.",
       operationId = "/email/duplicate-check"
   )
+  @ApiErrorCode({GlobalErrorCode.class, EmailDuplicationCheckErrorCode.class})
   @GetMapping("/email/duplicate-check")
   public ResponseEntity<EmailDuplicationCheckResponse> emailDuplicationCheck(
       @Schema(description = "이메일", example = "zerozero@drink.com") @Valid @Email String email) {

--- a/src/main/java/com/zerozero/auth/presentation/LoginUserController.java
+++ b/src/main/java/com/zerozero/auth/presentation/LoginUserController.java
@@ -1,8 +1,10 @@
 package com.zerozero.auth.presentation;
 
 import com.zerozero.auth.application.LoginUserUseCase;
+import com.zerozero.auth.application.LoginUserUseCase.LoginUserErrorCode;
 import com.zerozero.auth.application.LoginUserUseCase.LoginUserResponse.Tokens;
 import com.zerozero.auth.presentation.LoginUserController.LoginUserResponse.Token;
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
@@ -41,6 +43,7 @@ public class LoginUserController {
       description = "사용자가 이메일과 비밀번호를 입력하여 로그인합니다.",
       operationId = "/login"
   )
+  @ApiErrorCode({GlobalErrorCode.class, LoginUserErrorCode.class})
   @PostMapping("/login")
   public ResponseEntity<LoginUserResponse> loginUser(@Valid @RequestBody LoginUserRequest loginUserRequest) {
     LoginUserUseCase.LoginUserResponse loginUserResponse = loginUserUseCase.execute(

--- a/src/main/java/com/zerozero/auth/presentation/RefreshUserTokenController.java
+++ b/src/main/java/com/zerozero/auth/presentation/RefreshUserTokenController.java
@@ -1,8 +1,10 @@
 package com.zerozero.auth.presentation;
 
 import com.zerozero.auth.application.RefreshUserTokenUseCase;
+import com.zerozero.auth.application.RefreshUserTokenUseCase.RefreshUserTokenErrorCode;
 import com.zerozero.auth.application.RefreshUserTokenUseCase.RefreshUserTokenResponse.Tokens;
 import com.zerozero.auth.presentation.RefreshUserTokenController.RefreshUserTokenResponse.Token;
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.RefreshToken;
@@ -36,6 +38,7 @@ public class RefreshUserTokenController {
       description = "사용자의 리프레시 토큰을 통해 토큰을 재발급합니다.",
       operationId = "/refresh/token"
   )
+  @ApiErrorCode({GlobalErrorCode.class, RefreshUserTokenErrorCode.class})
   @PostMapping("/refresh/token")
   public ResponseEntity<RefreshUserTokenResponse> refreshUserToken(@Parameter(hidden = true) RefreshToken refreshToken) {
     RefreshUserTokenUseCase.RefreshUserTokenResponse refreshUserTokenResponse = refreshUserTokenUseCase.execute(

--- a/src/main/java/com/zerozero/auth/presentation/RegisterUserController.java
+++ b/src/main/java/com/zerozero/auth/presentation/RegisterUserController.java
@@ -1,6 +1,8 @@
 package com.zerozero.auth.presentation;
 
 import com.zerozero.auth.application.RegisterUserUseCase;
+import com.zerozero.auth.application.RegisterUserUseCase.RegisterUserErrorCode;
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.exception.error.GlobalErrorCode;
@@ -37,6 +39,7 @@ public class RegisterUserController {
       description = "사용자의 개인 정보를 통해 회원을 가입합니다.",
       operationId = "/register"
   )
+  @ApiErrorCode({GlobalErrorCode.class, RegisterUserErrorCode.class})
   @PostMapping("/register")
   public ResponseEntity<RegisterUserResponse> registerUser(@Valid @RequestBody RegisterUserRequest registerUserRequest) {
     RegisterUserUseCase.RegisterUserResponse registerUserResponse = registerUserUseCase.execute(

--- a/src/main/java/com/zerozero/configuration/swagger/ApiErrorCode.java
+++ b/src/main/java/com/zerozero/configuration/swagger/ApiErrorCode.java
@@ -1,0 +1,14 @@
+package com.zerozero.configuration.swagger;
+
+import com.zerozero.core.exception.error.BaseErrorCode;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCode {
+
+  Class<? extends BaseErrorCode>[] value();
+}

--- a/src/main/java/com/zerozero/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/com/zerozero/configuration/swagger/SwaggerConfiguration.java
@@ -1,14 +1,33 @@
 package com.zerozero.configuration.swagger;
 
+import com.zerozero.core.exception.error.BaseErrorCode;
+import com.zerozero.core.presentation.ErrorResponse;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
 
 @OpenAPIDefinition(
     info = @Info(title = "Zerozero API",
@@ -20,12 +39,80 @@ public class SwaggerConfiguration {
   @Bean
   public OpenAPI openAPI(){
     SecurityScheme securityScheme = new SecurityScheme()
-        .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
-        .in(SecurityScheme.In.HEADER).name("Authorization");
+        .type(Type.HTTP).scheme("bearer").bearerFormat("JWT")
+        .in(In.HEADER).name("Authorization");
     SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
     return new OpenAPI()
         .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
         .security(Arrays.asList(securityRequirement));
+  }
+
+  @Bean
+  public OperationCustomizer operationCustomizer() {
+    return (Operation operation, HandlerMethod handlerMethod) -> {
+      ApiErrorCode apiErrorCode = handlerMethod.getMethodAnnotation(ApiErrorCode.class);
+      if (apiErrorCode != null) {
+        generateErrorCodeResponseExample(operation, apiErrorCode.value());
+      }
+      return operation;
+    };
+  }
+
+  private void generateErrorCodeResponseExample(Operation operation, Class<? extends BaseErrorCode>[] types) {
+    ApiResponses responses = operation.getResponses();
+    List<ExampleHolder> exampleHolders = new ArrayList<>();
+
+    for (Class<? extends BaseErrorCode> type : types) {
+      BaseErrorCode[] errorCodes = type.getEnumConstants();
+      Arrays.stream(errorCodes).map(
+          baseErrorCode -> ExampleHolder.builder()
+              .holder(getSwaggerExample(baseErrorCode))
+              .code(baseErrorCode.getHttpStatus().value())
+              .name(baseErrorCode.name())
+              .build()
+      ).forEach(exampleHolders::add);
+    }
+
+    Map<Integer, List<ExampleHolder>> statusWithExampleHolders = new HashMap<>(
+        exampleHolders.stream()
+            .collect(Collectors.groupingBy(ExampleHolder::getCode)));
+
+    addExamplesToResponses(responses, statusWithExampleHolders);
+  }
+
+
+  private Example getSwaggerExample(BaseErrorCode baseErrorCode) {
+    ErrorResponse errorResponse = ErrorResponse.createErrorCode()
+        .statusCode(baseErrorCode.getHttpStatus().value())
+        .exception(baseErrorCode.toException())
+        .build();
+    Example example = new Example();
+    example.setValue(errorResponse);
+    return example;
+  }
+
+  private void addExamplesToResponses(ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+    statusWithExampleHolders.forEach(
+        (status, value) -> {
+          Content content = new Content();
+          MediaType mediaType = new MediaType();
+          ApiResponse apiResponse = new ApiResponse();
+          value.forEach(exampleHolder -> mediaType.addExamples(exampleHolder.getName(),
+              exampleHolder.getHolder()));
+          content.addMediaType("application/json", mediaType);
+          apiResponse.setContent(content);
+          responses.addApiResponse(status.toString(), apiResponse);
+        }
+    );
+  }
+
+  @Getter
+  @Builder
+  public static class ExampleHolder {
+
+    private Example holder;
+    private int code;
+    private String name;
   }
 }

--- a/src/main/java/com/zerozero/review/presentation/CreateStoreReviewController.java
+++ b/src/main/java/com/zerozero/review/presentation/CreateStoreReviewController.java
@@ -1,11 +1,13 @@
 package com.zerozero.review.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.ZeroDrink;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.review.application.CreateStoreReviewUseCase;
+import com.zerozero.review.application.CreateStoreReviewUseCase.CreateStoreReviewErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -39,6 +41,7 @@ public class CreateStoreReviewController {
       description = "판매점에 대한 리뷰를 등록합니다.",
       operationId = "/review"
   )
+  @ApiErrorCode({GlobalErrorCode.class, CreateStoreReviewErrorCode.class})
   @PostMapping("/review")
   public ResponseEntity<CreateStoreReviewResponse> createStoreReview(@RequestParam @Schema(description = "판매점 ID") UUID storeId,
       @RequestBody CreateStoreReviewRequest request,

--- a/src/main/java/com/zerozero/review/presentation/DeleteStoreReviewController.java
+++ b/src/main/java/com/zerozero/review/presentation/DeleteStoreReviewController.java
@@ -1,9 +1,11 @@
 package com.zerozero.review.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.review.application.DeleteStoreReviewUseCase;
+import com.zerozero.review.application.DeleteStoreReviewUseCase.DeleteStoreReviewErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,6 +36,7 @@ public class DeleteStoreReviewController {
       description = "리뷰 ID를 통해 리뷰를 삭제합니다.",
       operationId = "/review/{reviewId}"
   )
+  @ApiErrorCode({GlobalErrorCode.class, DeleteStoreReviewErrorCode.class})
   @DeleteMapping("/review/{reviewId}")
   public ResponseEntity<DeleteStoreReviewResponse> deleteStoreReview(@PathVariable(name = "reviewId") @Schema(description = "리뷰 ID") UUID reviewId,
       @Parameter(hidden = true) AccessToken accessToken) {

--- a/src/main/java/com/zerozero/review/presentation/LikeStoreReviewController.java
+++ b/src/main/java/com/zerozero/review/presentation/LikeStoreReviewController.java
@@ -1,9 +1,11 @@
 package com.zerozero.review.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.review.application.LikeStoreReviewUseCase;
+import com.zerozero.review.application.LikeStoreReviewUseCase.LikeStoreReviewErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,6 +36,7 @@ public class LikeStoreReviewController {
       description = "사용자가 리뷰 ID를 통해 좋아요를 누릅니다.",
       operationId = "/review/like/{reviewId}"
   )
+  @ApiErrorCode({GlobalErrorCode.class, LikeStoreReviewErrorCode.class})
   @PatchMapping("/review/like/{reviewId}")
   public ResponseEntity<LikeStoreReviewResponse> likeStoreReview(@PathVariable(name = "reviewId") @Schema(description = "리뷰 ID") UUID reviewId,
       @Parameter(hidden = true) AccessToken accessToken) {

--- a/src/main/java/com/zerozero/review/presentation/UpdateStoreReviewController.java
+++ b/src/main/java/com/zerozero/review/presentation/UpdateStoreReviewController.java
@@ -1,11 +1,13 @@
 package com.zerozero.review.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.ZeroDrink;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.review.application.UpdateStoreReviewUseCase;
+import com.zerozero.review.application.UpdateStoreReviewUseCase.UpdateStoreReviewErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -39,6 +41,7 @@ public class UpdateStoreReviewController {
       description = "리뷰 ID를 통해 리뷰를 수정합니다.",
       operationId = "/review/{reviewId}"
   )
+  @ApiErrorCode({GlobalErrorCode.class, UpdateStoreReviewErrorCode.class})
   @PatchMapping("/review/{reviewId}")
   public ResponseEntity<UpdateStoreReviewResponse> updateStoreReview(@PathVariable(name = "reviewId") @Schema(description = "리뷰 ID") UUID reviewId,
       @RequestBody UpdateStoreReviewRequest request,

--- a/src/main/java/com/zerozero/store/presentation/CreateStoreController.java
+++ b/src/main/java/com/zerozero/store/presentation/CreateStoreController.java
@@ -1,10 +1,12 @@
 package com.zerozero.store.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.store.application.CreateStoreUseCase;
+import com.zerozero.store.application.CreateStoreUseCase.CreateStoreErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,6 +44,7 @@ public class CreateStoreController {
       description = "사용자가 검색한 판매점 ID를 통해 제로음료 판매점을 등록합니다.",
       operationId = "/store"
   )
+  @ApiErrorCode({GlobalErrorCode.class, CreateStoreErrorCode.class})
   @PostMapping(value = "/store", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<CreateStoreResponse> createStore(@Valid @ParameterObject CreateStoreRequest request,
       @RequestPart @Parameter(description = "이미지 원본 파일") List<MultipartFile> imageFiles,

--- a/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
+++ b/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
@@ -1,5 +1,6 @@
 package com.zerozero.store.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.entity.Review.Filter;
@@ -13,6 +14,7 @@ import com.zerozero.review.application.ReadStoreReviewUseCase;
 import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewRequest;
 import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewResponse;
 import com.zerozero.store.application.ReadStoreInfoUseCase;
+import com.zerozero.store.application.ReadStoreInfoUseCase.ReadStoreInfoErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -49,6 +51,7 @@ public class ReadStoreInfoController {
       description = "판매점 ID를 통해 판매점과 리뷰를 조회합니다.",
       operationId = "/store"
   )
+  @ApiErrorCode({GlobalErrorCode.class, ReadStoreInfoErrorCode.class})
   @GetMapping("/store")
   public ResponseEntity<ReadStoreInfoResponse> readStoreInfo(@ParameterObject ReadStoreInfoRequest request,
       @Parameter(hidden = true) AccessToken accessToken) {

--- a/src/main/java/com/zerozero/store/presentation/SearchStoreController.java
+++ b/src/main/java/com/zerozero/store/presentation/SearchStoreController.java
@@ -1,11 +1,13 @@
 package com.zerozero.store.presentation;
 
+import  com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.Store;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.store.application.SearchStoreUseCase;
+import com.zerozero.store.application.SearchStoreUseCase.SearchStoreErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -38,6 +40,7 @@ public class SearchStoreController {
       description = "등록할 판매점을 쿼리를 통해 검색합니다.",
       operationId = "/store/search"
   )
+  @ApiErrorCode({GlobalErrorCode.class, SearchStoreErrorCode.class})
   @GetMapping("/store/search")
   public ResponseEntity<SearchStoreResponse> searchStore(@ParameterObject SearchStoreRequest request,
       @Parameter(hidden = true) AccessToken accessToken) {

--- a/src/main/java/com/zerozero/user/presentation/ReadUserInfoController.java
+++ b/src/main/java/com/zerozero/user/presentation/ReadUserInfoController.java
@@ -1,10 +1,12 @@
 package com.zerozero.user.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.record.UserProfile;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.user.application.ReadUserInfoUseCase;
+import com.zerozero.user.application.ReadUserInfoUseCase.ReadUserInfoErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,6 +36,7 @@ public class ReadUserInfoController {
       description = "사용자의 마이페이지를 토큰을 통해 조회합니다.",
       operationId = "/user/mypage"
   )
+  @ApiErrorCode({GlobalErrorCode.class, ReadUserInfoErrorCode.class})
   @GetMapping("/user/mypage")
   public ResponseEntity<ReadUserInfoResponse> readUserInfo(@Parameter(hidden = true) AccessToken accessToken) {
     ReadUserInfoUseCase.ReadUserInfoResponse readUserInfoResponse = readUserInfoUseCase.execute(

--- a/src/main/java/com/zerozero/user/presentation/ReadUserStoresController.java
+++ b/src/main/java/com/zerozero/user/presentation/ReadUserStoresController.java
@@ -1,10 +1,12 @@
 package com.zerozero.user.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.Store;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.user.application.ReadUserStoresUseCase;
+import com.zerozero.user.application.ReadUserStoresUseCase.ReadUserStoresErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,6 +37,7 @@ public class ReadUserStoresController {
       description = "사용자가 등록한 판매점 목록을 조회합니다.",
       operationId = "/user/stores"
   )
+  @ApiErrorCode({GlobalErrorCode.class, ReadUserStoresErrorCode.class})
   @GetMapping("/user/stores")
   public ResponseEntity<ReadUserStoresResponse> readUserStores(@Parameter(hidden = true) AccessToken accessToken) {
     ReadUserStoresUseCase.ReadUserStoresResponse readUserStoresResponse = readUserStoresUseCase.execute(

--- a/src/main/java/com/zerozero/user/presentation/UploadProfileImageController.java
+++ b/src/main/java/com/zerozero/user/presentation/UploadProfileImageController.java
@@ -1,9 +1,11 @@
 package com.zerozero.user.presentation;
 
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.user.application.UploadProfileImageUseCase;
+import com.zerozero.user.application.UploadProfileImageUseCase.UploadProfileImageErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,6 +37,7 @@ public class UploadProfileImageController {
       description = "사용자가 이미지 파일을 통해 프로필 사진을 등록합니다.",
       operationId = "/user/image"
   )
+  @ApiErrorCode({GlobalErrorCode.class, UploadProfileImageErrorCode.class})
   @PostMapping(value = "/user/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<UploadProfileImageResponse> uploadProfileImage(
       @RequestPart @Parameter(description = "이미지 원본 파일") MultipartFile imageFile,


### PR DESCRIPTION
스웨거에서 200 응답 코드 이외 에러 코드 예시 반환하는 작업으로

[에러코드 참고 블로그](https://devnm.tistory.com/29) 이용해서 스웨거에서 에러코드 예시 노출되게 하였습니다.

`@ApiErrorCode` 어노테이션 생성하여 모든 컨트롤러 메소드에 적용하였습니다.

로컬에서 스웨거 확인하였습니다.