### PR TITLE
FEAT: (#65) 카카오 로컬 REST API를 연동한다

### DIFF
--- a/src/main/java/com/zerozero/external/kakao/search/application/RequestKakaoKeywordSearchUseCase.java
+++ b/src/main/java/com/zerozero/external/kakao/search/application/RequestKakaoKeywordSearchUseCase.java
@@ -1,0 +1,146 @@
+package com.zerozero.external.kakao.search.application;
+
+import com.zerozero.core.application.BaseRequest;
+import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.application.BaseUseCase;
+import com.zerozero.core.exception.DomainException;
+import com.zerozero.core.exception.error.BaseErrorCode;
+import com.zerozero.external.kakao.search.application.RequestKakaoKeywordSearchUseCase.RequestKakaoKeywordSearchRequest;
+import com.zerozero.external.kakao.search.application.RequestKakaoKeywordSearchUseCase.RequestKakaoKeywordSearchResponse;
+import com.zerozero.external.kakao.search.core.configuration.KakaoProperty;
+import com.zerozero.external.kakao.search.dto.CategoryGroupCode;
+import com.zerozero.external.kakao.search.dto.KeywordSearchResponse;
+import java.net.URI;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class RequestKakaoKeywordSearchUseCase implements BaseUseCase<RequestKakaoKeywordSearchRequest, RequestKakaoKeywordSearchResponse> {
+
+  private final KakaoProperty kakaoProperty;
+
+  @Override
+  public RequestKakaoKeywordSearchResponse execute(RequestKakaoKeywordSearchRequest request) {
+    if (request == null || !request.isValid()) {
+      log.error("[RequestKakaoKeywordSearchUseCase] RequestKakaoKeywordSearchRequest is invalid.");
+      return RequestKakaoKeywordSearchResponse.builder()
+          .success(false)
+          .errorCode(RequestKakaoKeywordSearchErrorCode.INVALID_REQUEST)
+          .build();
+    }
+    final String KAKAO_AUTHORIZATION_PREFIX = "KakaoAK ";
+
+    URI uri = UriComponentsBuilder.fromUriString(kakaoProperty.getKeywordUrl())
+        .queryParams(request.createQueryParams())
+        .build()
+        .encode()
+        .toUri();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", KAKAO_AUTHORIZATION_PREFIX + kakaoProperty.getRestApiKey());
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    HttpEntity httpEntity = new HttpEntity<>(headers);
+    ParameterizedTypeReference<KeywordSearchResponse> responseType = new ParameterizedTypeReference<>() {};
+    ResponseEntity<KeywordSearchResponse> responseEntity = new RestTemplate().exchange(uri, HttpMethod.GET, httpEntity, responseType);
+    return RequestKakaoKeywordSearchResponse.builder().keywordSearchResponse(responseEntity.getBody()).build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum RequestKakaoKeywordSearchErrorCode implements BaseErrorCode<DomainException> {
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class RequestKakaoKeywordSearchResponse extends BaseResponse<RequestKakaoKeywordSearchErrorCode> {
+
+    private KeywordSearchResponse keywordSearchResponse;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class RequestKakaoKeywordSearchRequest implements BaseRequest {
+
+    private String query;
+
+    private CategoryGroupCode categoryGroupCode;
+
+    private String longitude;
+
+    private String latitude;
+
+    private Integer radius;
+
+    private String rect;
+
+    private Integer page;
+
+    private Integer size;
+
+    private String sort;
+
+    public MultiValueMap<String, String> createQueryParams() {
+      LinkedMultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+
+      queryParams.add("query", query);
+      queryParams.add("category_group_code",
+          Optional.ofNullable(categoryGroupCode).map(CategoryGroupCode::toString).orElse(null));
+      queryParams.add("x", longitude);
+      queryParams.add("y", latitude);
+      queryParams.add("radius", Optional.ofNullable(radius).map(String::valueOf).orElse(null));
+      queryParams.add("rect", rect);
+      queryParams.add("page", Optional.ofNullable(page).map(String::valueOf).orElse(null));
+      queryParams.add("size", Optional.ofNullable(size).map(String::valueOf).orElse(null));
+      queryParams.add("sort", sort);
+
+      return queryParams;
+    }
+
+    @Override
+    public boolean isValid() {
+      return query != null && !query.isEmpty();
+    }
+  }
+}

--- a/src/main/java/com/zerozero/external/kakao/search/core/configuration/KakaoProperty.java
+++ b/src/main/java/com/zerozero/external/kakao/search/core/configuration/KakaoProperty.java
@@ -1,0 +1,17 @@
+package com.zerozero.external.kakao.search.core.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("kakao")
+@Getter
+@Setter
+public class KakaoProperty {
+
+  private String restApiKey;
+
+  private String keywordUrl;
+}

--- a/src/main/java/com/zerozero/external/kakao/search/dto/CategoryGroupCode.java
+++ b/src/main/java/com/zerozero/external/kakao/search/dto/CategoryGroupCode.java
@@ -1,0 +1,15 @@
+package com.zerozero.external.kakao.search.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryGroupCode {
+
+  MT1("대형마트"), CS2("편의점"), PS3("어린이집, 유치원"), SC4("학교"), AC5("학원"), PK6("주차장"), OL7("주유소, 충전소"),
+  SW8("지하철역"), BK9("은행"), CT1("문화시설"), AG2("중개업소"), PO3("공공기관"), AT4("관광명소"), AD5("숙박"), FD6("음식점"), CE7("카페"), HP8("병원"), PM9(
+      "약국");
+
+  private final String description;
+}

--- a/src/main/java/com/zerozero/external/kakao/search/dto/KeywordSearchResponse.java
+++ b/src/main/java/com/zerozero/external/kakao/search/dto/KeywordSearchResponse.java
@@ -1,0 +1,79 @@
+package com.zerozero.external.kakao.search.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KeywordSearchResponse {
+
+  private Meta meta;
+
+  private Document[] documents;
+
+  @Getter
+  @Setter
+  public static class Meta {
+
+    @JsonProperty("total_count")
+    private Integer totalCount;
+
+    @JsonProperty("pageable_count")
+    private Integer pageableCount;
+
+    @JsonProperty("is_end")
+    private Boolean isEnd;
+
+    @JsonProperty("same_name")
+    private SameName sameName;
+
+    @Getter
+    @Setter
+    public static class SameName {
+
+      private String[] region;
+
+      private String keyword;
+
+      @JsonProperty("selected_region")
+      private String selectedRegion;
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class Document {
+
+    private String id;
+
+    @JsonProperty("place_name")
+    private String placeName;
+
+    @JsonProperty("category_name")
+    private String categoryName;
+
+    @JsonProperty("category_group_code")
+    private String categoryGroupCode;
+
+    @JsonProperty("category_group_name")
+    private String categoryGroupName;
+
+    private String phone;
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("road_address_name")
+    private String roadAddressName;
+
+    private String x;
+
+    private String y;
+
+    @JsonProperty("place_url")
+    private String placeUrl;
+
+    private String distance;
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,10 @@ naver:
     id: ENC(+360t44DgPZsqSUxThTfvgjE34sgxwfuKlSkCKVjq10=)
     secret: ENC(Ed98V/o2RX3XhBYyxPMkvyt9jzj2O/xR)
 
+kakao:
+  restApiKey: ENC(uyN1NUoVEVS8SB0PGCUSU3oSW6oTn3TZCewIDULwi9e2UMAAqnVOZbrO2a7XWb1R)
+  keywordUrl: https://dapi.kakao.com/v2/local/search/keyword.json
+
 cloud:
   aws:
     credentials:

--- a/src/test/java/com/zerozero/external/kakao/search/core/configuration/KakaoPropertyTest.java
+++ b/src/test/java/com/zerozero/external/kakao/search/core/configuration/KakaoPropertyTest.java
@@ -1,0 +1,42 @@
+package com.zerozero.external.kakao.search.core.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zerozero.external.kakao.search.application.RequestKakaoKeywordSearchUseCase;
+import com.zerozero.external.kakao.search.application.RequestKakaoKeywordSearchUseCase.RequestKakaoKeywordSearchRequest;
+import com.zerozero.external.kakao.search.dto.KeywordSearchResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("local")
+class KakaoPropertyTest {
+
+  @Autowired
+  RequestKakaoKeywordSearchUseCase requestKakaoKeywordSearchUseCase;
+
+  @Test
+  @DisplayName("서울 강남구 삼성동 20km 반경에서 카카오프렌즈 매장 검색한다.")
+  void keywordLocalSearch_SearchWithin20KmRadius_KakaoFriendsStoresFound() {
+
+    // given
+    RequestKakaoKeywordSearchRequest request = RequestKakaoKeywordSearchRequest.builder()
+        .query("카카오프렌즈")
+        .latitude("37.514322572335935")
+        .longitude("127.06283102249932")
+        .radius(20000)
+        .build();
+
+    // when
+    KeywordSearchResponse response = requestKakaoKeywordSearchUseCase.execute(request).getKeywordSearchResponse();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getMeta()).isNotNull();
+    assertThat(response.getMeta().getSameName()).isNotNull();
+    assertThat(response.getMeta().getSameName().getKeyword()).isEqualTo("카카오프렌즈");
+  }
+}


### PR DESCRIPTION
네이버 Open API에서 카카오 Open API로 마이그레이션하는 첫 번째 작업으로

키워드(판매점명)를 이용해서 판매점 검색 결과를 가져오는 API를 이용하였습니다. ([Kakao Developers Docs](https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword))

property에 카카오 관련 값(API key, URL) 추가되었습니다.

로컬에서 테스트 진행하였습니다.