### PR TITLE
FIX: (#80) 사용자 회원가입에서 닉네임 중복 검증 로직을 제거한다

### DIFF
--- a/src/main/java/com/zerozero/auth/application/RegisterUserUseCase.java
+++ b/src/main/java/com/zerozero/auth/application/RegisterUserUseCase.java
@@ -47,11 +47,6 @@ public class RegisterUserUseCase implements BaseUseCase<RegisterUserRequest, Reg
       return RegisterUserResponse.builder().success(false)
           .errorCode(RegisterUserErrorCode.ALREADY_EXIST_EMAIL).build();
     }
-    if (isDuplicateNickname(request.getNickname())) {
-      log.error("[RegisterUserUseCase] Nickname already exists");
-      return RegisterUserResponse.builder().success(false)
-          .errorCode(RegisterUserErrorCode.ALREADY_EXIST_NICKNAME).build();
-    }
     User user = User.builder()
         .nickname(request.getNickname())
         .email(request.getEmail())
@@ -66,17 +61,12 @@ public class RegisterUserUseCase implements BaseUseCase<RegisterUserRequest, Reg
     return userJPARepository.existsByEmail(email);
   }
 
-  private boolean isDuplicateNickname(String nickname) {
-    return userJPARepository.existsByNickname(nickname);
-  }
-
   @Getter
   @RequiredArgsConstructor
   public enum RegisterUserErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_REGISTER_CONDITION(HttpStatus.BAD_REQUEST, "회원가입 조건이 올바르지 않습니다."),
-    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.");
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
 
     private final HttpStatus httpStatus;
 


### PR DESCRIPTION
사용자 회원가입에서 닉네임이 중복되어도 괜찮을 거 같다는 논의 하에

닉네임 중복 검증 로직을 제거하였습니다.