### PR TITLE
FEAT: (#75) Mongo DB에 판매점 등록 시 경,위도를 GeoJson 타입으로 변경한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/infra/mongodb/GeoJson.java
+++ b/src/main/java/com/zerozero/core/domain/infra/mongodb/GeoJson.java
@@ -1,4 +1,4 @@
-package com.zerozero.core.domain.infra.mongodb.region;
+package com.zerozero.core.domain.infra.mongodb;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/zerozero/core/domain/infra/mongodb/GeoJsonConverter.java
+++ b/src/main/java/com/zerozero/core/domain/infra/mongodb/GeoJsonConverter.java
@@ -1,0 +1,22 @@
+package com.zerozero.core.domain.infra.mongodb;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+
+@Log4j2
+public class GeoJsonConverter {
+
+  public static GeoJsonPoint of(String longitude, String latitude) {
+    if (longitude == null || latitude == null) {
+      return null;
+    }
+    try {
+      double x = Double.parseDouble(longitude);
+      double y = Double.parseDouble(latitude);
+      return new GeoJsonPoint(x, y);
+    } catch (NumberFormatException e) {
+      log.error(e);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/zerozero/core/domain/infra/mongodb/region/Region.java
+++ b/src/main/java/com/zerozero/core/domain/infra/mongodb/region/Region.java
@@ -1,6 +1,7 @@
 package com.zerozero.core.domain.infra.mongodb.region;
 
 
+import com.zerozero.core.domain.infra.mongodb.GeoJson;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/zerozero/core/domain/infra/mongodb/store/Store.java
+++ b/src/main/java/com/zerozero/core/domain/infra/mongodb/store/Store.java
@@ -1,5 +1,6 @@
 package com.zerozero.core.domain.infra.mongodb.store;
 
+import com.zerozero.core.domain.infra.mongodb.GeoJsonConverter;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @ToString
@@ -15,7 +17,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Document(collation = "store")
+@Document(collection = "store")
 public class Store {
 
   private UUID storeId;
@@ -36,6 +38,8 @@ public class Store {
 
   private String latitude;
 
+  private GeoJsonPoint location;
+
   private String placeUrl;
 
   private UUID userId;
@@ -54,6 +58,7 @@ public class Store {
         .roadAddress(store.getRoadAddress())
         .longitude(store.getLongitude())
         .latitude(store.getLatitude())
+        .location(GeoJsonConverter.of(store.getLongitude(), store.getLatitude()))
         .placeUrl(store.getPlaceUrl())
         .userId(store.getUserId())
         .build();


### PR DESCRIPTION
Mongo DB에서 실시간 위치 기반으로 주변 등록 판매점을 조회하기 위해

GeoJsonPoint 타입을 이용해 location 좌표로 변환 저장하여

추후 실시간 조회에서 사용하기 위한 밑작업입니다.