### PR TITLE
FEAT: (#74) 사용자 실시간 위치 기반으로 등록된 판매점을 조회할 수 있다

### DIFF
--- a/src/main/java/com/zerozero/configuration/WebSocketConfiguration.java
+++ b/src/main/java/com/zerozero/configuration/WebSocketConfiguration.java
@@ -1,0 +1,21 @@
+package com.zerozero.configuration;
+
+import com.zerozero.webSocket.handler.ReadNearbyStoresWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfiguration implements WebSocketConfigurer {
+
+  private final ReadNearbyStoresWebSocketHandler readNearbyStoresWebSocketHandler;
+
+  @Override
+  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+    registry.addHandler(readNearbyStoresWebSocketHandler, "/ws/store").setAllowedOrigins("*");
+  }
+}

--- a/src/main/java/com/zerozero/core/domain/infra/mongodb/store/StoreMongoRepository.java
+++ b/src/main/java/com/zerozero/core/domain/infra/mongodb/store/StoreMongoRepository.java
@@ -1,8 +1,12 @@
 package com.zerozero.core.domain.infra.mongodb.store;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface StoreMongoRepository extends MongoRepository<Store, UUID> {
 
+  @Query("{ 'location': { $near: { $geometry: { type: 'Point', coordinates: [?0, ?1] }, $maxDistance: ?2 } } }")
+  List<Store> findStoresWithinCoordinatesRadius(double longitude, double latitude, double maxDistance);
 }

--- a/src/main/java/com/zerozero/store/application/ReadNearbyStoresUseCase.java
+++ b/src/main/java/com/zerozero/store/application/ReadNearbyStoresUseCase.java
@@ -1,0 +1,126 @@
+package com.zerozero.store.application;
+
+import com.zerozero.core.application.BaseRequest;
+import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.application.BaseUseCase;
+import com.zerozero.core.domain.entity.User;
+import com.zerozero.core.domain.infra.mongodb.store.Store;
+import com.zerozero.core.domain.infra.mongodb.store.StoreMongoRepository;
+import com.zerozero.core.domain.infra.repository.UserJPARepository;
+import com.zerozero.core.domain.vo.AccessToken;
+import com.zerozero.core.exception.DomainException;
+import com.zerozero.core.exception.error.BaseErrorCode;
+import com.zerozero.core.util.JwtUtil;
+import com.zerozero.store.application.ReadNearbyStoresUseCase.ReadNearbyStoresRequest;
+import com.zerozero.store.application.ReadNearbyStoresUseCase.ReadNearbyStoresResponse;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadNearbyStoresUseCase implements BaseUseCase<ReadNearbyStoresRequest, ReadNearbyStoresResponse> {
+
+  private final JwtUtil jwtUtil;
+
+  private final UserJPARepository userJPARepository;
+
+  private final StoreMongoRepository storeMongoRepository;
+
+  public static final Double DEFAULT_RADIUS = 100.0;
+
+  @Override
+  public ReadNearbyStoresResponse execute(ReadNearbyStoresRequest request) {
+    if (request == null || !request.isValid()) {
+      log.error("[ReadNearbyStoresUseCase] Invalid request");
+      return ReadNearbyStoresResponse.builder()
+          .success(false)
+          .errorCode(ReadNearbyStoresErrorCode.NOT_EXIST_REQUEST_CONDITION)
+          .build();
+    }
+    AccessToken accessToken = request.getAccessToken();
+    if (jwtUtil.isTokenExpired(accessToken.getToken())) {
+      log.error("[ReadNearbyStoresUseCase] Expired access token");
+      return ReadNearbyStoresResponse.builder()
+          .success(false)
+          .errorCode(ReadNearbyStoresErrorCode.EXPIRED_TOKEN)
+          .build();
+    }
+    String userEmail = jwtUtil.extractUsername(accessToken.getToken());
+    User user = userJPARepository.findByEmail(userEmail);
+    if (user == null) {
+      log.error("[ReadNearbyStoresUseCase] not found user with email {}", userEmail);
+      return ReadNearbyStoresResponse.builder()
+          .success(false)
+          .errorCode(ReadNearbyStoresErrorCode.NOT_EXIST_USER)
+          .build();
+    }
+    List<Store> stores = storeMongoRepository.findStoresWithinCoordinatesRadius(request.getLongitude(), request.getLatitude(), DEFAULT_RADIUS);
+    return ReadNearbyStoresResponse.builder()
+        .success(true)
+        .stores(stores)
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ReadNearbyStoresErrorCode implements BaseErrorCode<DomainException> {
+    NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "검색 요청 조건이 올바르지 않습니다."),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class ReadNearbyStoresResponse extends BaseResponse<ReadNearbyStoresErrorCode> {
+
+    private List<Store> stores;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class ReadNearbyStoresRequest implements BaseRequest {
+
+    private Double longitude;
+
+    private Double latitude;
+
+    private AccessToken accessToken;
+
+    @Override
+    public boolean isValid() {
+      return longitude != null && latitude != null && accessToken != null;
+    }
+  }
+
+}

--- a/src/main/java/com/zerozero/webSocket/handler/ReadNearbyStoresWebSocketHandler.java
+++ b/src/main/java/com/zerozero/webSocket/handler/ReadNearbyStoresWebSocketHandler.java
@@ -1,0 +1,86 @@
+package com.zerozero.webSocket.handler;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerozero.core.application.BaseRequest;
+import com.zerozero.core.domain.vo.AccessToken;
+import com.zerozero.store.application.ReadNearbyStoresUseCase;
+import com.zerozero.store.application.ReadNearbyStoresUseCase.ReadNearbyStoresRequest;
+import com.zerozero.store.application.ReadNearbyStoresUseCase.ReadNearbyStoresResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Log4j2
+@Controller
+@RequiredArgsConstructor
+public class ReadNearbyStoresWebSocketHandler extends TextWebSocketHandler {
+
+  private final ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private final ReadNearbyStoresUseCase readNearbyStoresUseCase;
+
+  @Override
+  protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    String payload = message.getPayload();
+    ReadNearbyStoresWebSocketRequest request = objectMapper.readValue(payload, ReadNearbyStoresWebSocketRequest.class);
+    if (request == null || !request.isValid()) {
+      log.error("[ReadNearbyStoresWebSocketHandler] request is null");
+      return;
+    }
+    ReadNearbyStoresResponse readNearbyStoresResponse = readNearbyStoresUseCase.execute(
+        ReadNearbyStoresRequest.builder()
+            .longitude(request.getLongitude())
+            .latitude(request.getLatitude())
+            .accessToken(request.getAccessToken())
+            .build());
+    if (readNearbyStoresResponse == null) {
+      log.error("[ReadNearbyStoresWebSocketHandler] readNearbyStoresResponse is null");
+      return;
+    }
+    session.sendMessage(new TextMessage(objectMapper.writeValueAsString(readNearbyStoresResponse)));
+  }
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    log.info("[ReadNearbyStoresWebSocketHandler] Connection established: {}", session.getId());
+    super.afterConnectionEstablished(session);
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+    log.info("[ReadNearbyStoresWebSocketHandler] Connection closed: {} with status {}", session.getId(), status);
+    super.afterConnectionClosed(session, status);
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class ReadNearbyStoresWebSocketRequest implements BaseRequest {
+
+    private Double longitude;
+
+    private Double latitude;
+
+    private AccessToken accessToken;
+
+    @Override
+    public boolean isValid() {
+      return longitude != null && latitude != null && accessToken != null;
+    }
+  }
+}


### PR DESCRIPTION
사용자 실시간 위치 기반으로 등록된 판매점 조회하는 작업으로

웹소켓 방식을 이용해서 1회 HandShake 연결 후 사용자의 좌표가 변경될 때마다 

요청 및 응답이 이뤄지며 사용자가 페이지를 넘어갈 경우 Disconnect하는 방식으로 이뤄집니다.

Disconnect는 프론트에서 처리 이뤄져야할 것으로 보입니다.

추후 Https로 변경할 때 웹소켓 또한 ws에서 wss로 변경되어야 하는데 이 부분은 추후 변경 예정입니다.

close #74 