### PR TITLE
FIX: (#86) 도메인 에러 처리에서 토큰 만료의 에러 코드를 변경한다

### DIFF
--- a/src/main/java/com/zerozero/auth/application/RefreshUserTokenUseCase.java
+++ b/src/main/java/com/zerozero/auth/application/RefreshUserTokenUseCase.java
@@ -87,7 +87,7 @@ public class RefreshUserTokenUseCase implements BaseUseCase<RefreshUserTokenRequ
   @RequiredArgsConstructor
   public enum RefreshUserTokenErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 존재하지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER_EMAIL(HttpStatus.BAD_REQUEST, "토큰에 사용자 메일이 존재하지 않습니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     TOKEN_REFRESH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 재발급에 실패하였습니다.");

--- a/src/main/java/com/zerozero/review/application/CreateStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/CreateStoreReviewUseCase.java
@@ -99,7 +99,7 @@ public class CreateStoreReviewUseCase implements BaseUseCase<CreateStoreReviewRe
   @RequiredArgsConstructor
   public enum CreateStoreReviewErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REVIEW_CONDITION(HttpStatus.BAD_REQUEST, "리뷰 요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_STORE(HttpStatus.BAD_REQUEST, "등록된 판매점이 존재하지 않습니다."),
     ALREADY_USER_REVIEWED(HttpStatus.INTERNAL_SERVER_ERROR, "이미 리뷰를 작성한 사용자입니다.");

--- a/src/main/java/com/zerozero/review/application/DeleteStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/DeleteStoreReviewUseCase.java
@@ -89,7 +89,7 @@ public class DeleteStoreReviewUseCase implements BaseUseCase<DeleteStoreReviewRe
   @RequiredArgsConstructor
   public enum DeleteStoreReviewErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REVIEW_CONDITION(HttpStatus.BAD_REQUEST, "리뷰 삭제 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_DELETABLE_REVIEW(HttpStatus.BAD_REQUEST, "삭제 가능한 리뷰가 존재하지 않습니다."),
     USER_VALIDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰를 작성한 사용자가 아닙니다.");

--- a/src/main/java/com/zerozero/review/application/LikeStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/LikeStoreReviewUseCase.java
@@ -91,7 +91,7 @@ public class LikeStoreReviewUseCase implements BaseUseCase<LikeStoreReviewReques
   @RequiredArgsConstructor
   public enum LikeStoreReviewErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REVIEW_LIKE_CONDITION(HttpStatus.BAD_REQUEST, "리뷰 좋아요 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_DELETABLE_REVIEW(HttpStatus.BAD_REQUEST, "삭제 가능한 리뷰가 존재하지 않습니다.");
 

--- a/src/main/java/com/zerozero/review/application/UpdateStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/UpdateStoreReviewUseCase.java
@@ -91,7 +91,7 @@ public class UpdateStoreReviewUseCase implements BaseUseCase<UpdateStoreReviewRe
   @RequiredArgsConstructor
   public enum UpdateStoreReviewErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REVIEW_CONDITION(HttpStatus.BAD_REQUEST, "리뷰 요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_REVIEW(HttpStatus.BAD_REQUEST, "리뷰가 존재하지 않습니다."),
     USER_VALIDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "리뷰를 작성한 사용자가 아닙니다.");

--- a/src/main/java/com/zerozero/store/application/CreateStoreUseCase.java
+++ b/src/main/java/com/zerozero/store/application/CreateStoreUseCase.java
@@ -133,7 +133,7 @@ public class CreateStoreUseCase implements BaseUseCase<CreateStoreRequest, Creat
   @RequiredArgsConstructor
   public enum CreateStoreErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "등록 요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_SEARCH_RESPONSE(HttpStatus.BAD_REQUEST, "검색 응답이 존재하지 않습니다."),
     NOT_EXIST_STORE(HttpStatus.BAD_REQUEST, "등록된 판매점이 존재하지 않습니다."),

--- a/src/main/java/com/zerozero/store/application/ReadNearbyStoresUseCase.java
+++ b/src/main/java/com/zerozero/store/application/ReadNearbyStoresUseCase.java
@@ -79,7 +79,7 @@ public class ReadNearbyStoresUseCase implements BaseUseCase<ReadNearbyStoresRequ
   @RequiredArgsConstructor
   public enum ReadNearbyStoresErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "검색 요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zerozero/store/application/ReadStoreInfoUseCase.java
+++ b/src/main/java/com/zerozero/store/application/ReadStoreInfoUseCase.java
@@ -80,7 +80,7 @@ public class ReadStoreInfoUseCase implements BaseUseCase<ReadStoreInfoRequest, R
   @RequiredArgsConstructor
   public enum ReadStoreInfoErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "검색 요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_SEARCH_RESPONSE(HttpStatus.BAD_REQUEST, "검색 응답이 존재하지 않습니다."),
     NOT_EXIST_STORE(HttpStatus.BAD_REQUEST, "등록된 판매점이 존재하지 않습니다.");

--- a/src/main/java/com/zerozero/store/application/SearchStoreUseCase.java
+++ b/src/main/java/com/zerozero/store/application/SearchStoreUseCase.java
@@ -103,7 +103,7 @@ public class SearchStoreUseCase implements BaseUseCase<SearchStoreRequest, Searc
   @RequiredArgsConstructor
   public enum SearchStoreErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_SEARCH_CONDITION(HttpStatus.BAD_REQUEST, "검색 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     NOT_EXIST_SEARCH_RESPONSE(HttpStatus.BAD_REQUEST, "검색 응답이 존재하지 않습니다.");
 

--- a/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
+++ b/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
@@ -72,6 +72,7 @@ public class ReadStoreInfoController {
     ReadStoreReviewResponse readStoreReviewResponse = readStoreReviewUseCase.execute(ReadStoreReviewRequest.builder()
         .storeId(request.getStoreId())
         .filter(request.getFilter())
+        .accessToken(accessToken)
         .build());
     if (readStoreReviewResponse == null || !readStoreReviewResponse.isSuccess()) {
       Optional.ofNullable(readStoreReviewResponse)

--- a/src/main/java/com/zerozero/user/application/ReadUserInfoUseCase.java
+++ b/src/main/java/com/zerozero/user/application/ReadUserInfoUseCase.java
@@ -88,7 +88,7 @@ public class ReadUserInfoUseCase implements BaseUseCase<ReadUserInfoRequest, Rea
   @RequiredArgsConstructor
   public enum ReadUserInfoErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zerozero/user/application/ReadUserStoresUseCase.java
+++ b/src/main/java/com/zerozero/user/application/ReadUserStoresUseCase.java
@@ -72,7 +72,7 @@ public class ReadUserStoresUseCase implements BaseUseCase<ReadUserStoresRequest,
   @RequiredArgsConstructor
   public enum ReadUserStoresErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zerozero/user/application/UpdateUserProfileUseCase.java
+++ b/src/main/java/com/zerozero/user/application/UpdateUserProfileUseCase.java
@@ -91,7 +91,7 @@ public class UpdateUserProfileUseCase implements BaseUseCase<UpdateUserProfileRe
   @RequiredArgsConstructor
   public enum UpdateUserProfileErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     FAILED_IMAGE_CONVERT(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환에 실패하였습니다.");
 


### PR DESCRIPTION
토큰 만료 에러코드를 400 BAD_REQUEST에서 401 UNAUTHORIZED로 변경하는 작업입니다.

추가로 판매점 리뷰 조회 UseCase에서 토큰 없이 조회 가능한 이슈를 확인하여

커밋 하나 추가해서 이슈 수정 작업하였습니다.