### PR TITLE
FIX: (#89) 리뷰 조회 시 필터의 기본 값은 최신순으로 변경한다

### DIFF
--- a/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
+++ b/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -146,7 +147,8 @@ public class ReadStoreInfoController {
     @Schema(description = "판매점 ID", example = "11ef3e05-f45b-7e6c-a084-7b554bfaa162")
     private UUID storeId;
 
-    @Schema(description = "리뷰 정렬 조건 : RECENT(최신순), RECOMMEND(추천순)", example = "RECOMMEND")
-    private Filter filter;
+    @Schema(description = "리뷰 정렬 조건 : RECENT(최신순), RECOMMEND(추천순)", example = "RECENT")
+    @Builder.Default
+    private Filter filter = Filter.RECENT;
   }
 }


### PR DESCRIPTION
판매점 조회에서 리뷰 조회 시 필터의 기본 값을 최신순으로 변경하는 작업으로

리뷰 필터의 도메인 메소드를 변경하면 향후 필터 도메인 메소드를 사용할 때 메소드의 책임이 분산되기 때문에

판매점 조회에서의 필터만 수정하는 방향으로 변경하였습니다.

로컬에서 테스트 진행하였습니다.