### PR TITLE
FIX: (#92) 가게제보 페이지에서 판매점 검색 시 사용되지 않는 이미지 배열을 응답에서 제거한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/record/Store.java
+++ b/src/main/java/com/zerozero/core/domain/record/Store.java
@@ -1,0 +1,37 @@
+package com.zerozero.core.domain.record;
+
+import com.zerozero.core.domain.vo.Image;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record Store(
+    @Schema(description = "판매점 ID", example = "8e3006f4-3a16-11ef-9454-0242ac120002") UUID id,
+    @Schema(description = "카카오 ID", example = "25770215") String kakaoId,
+    @Schema(description = "판매점 이름", example = "제로 피자") String name,
+    @Schema(description = "판매 종류", example = "음식점 > 한식 > 육류,고기") String category,
+    @Schema(description = "전화번호", example = "02-525-6692") String phone,
+    @Schema(description = "판매점 주소", example = "서울특별시 서초구 서초동") String address,
+    @Schema(description = "판매점 도로명 주소", example = "서울특별시 서초구 서초대로50길 82 정원빌딩") String roadAddress,
+    @Schema(description = "판매점 x좌표(경도)", example = "127.01275515884753") String longitude,
+    @Schema(description = "판매점 y좌표(위도)", example = "37.49206032952165") String latitude,
+    @Schema(description = "제로음료 판매 여부", example = "true") Boolean status,
+    @Schema(description = "제로음료 등록 이미지 목록") Image[] images,
+    @Schema(description = "판매점 상세페이지 URL", example = "http://place.map.kakao.com/25770215") String placeUrl) {
+
+  public static Store of(com.zerozero.core.domain.vo.Store store) {
+    return new Store(
+        store.getId(),
+        store.getKakaoId(),
+        store.getName(),
+        store.getCategory(),
+        store.getPhone(),
+        store.getAddress(),
+        store.getRoadAddress(),
+        store.getLongitude(),
+        store.getLatitude(),
+        store.getStatus(),
+        store.getImages(),
+        store.getPlaceUrl()
+    );
+  }
+}

--- a/src/main/java/com/zerozero/core/domain/record/StoreWithoutImages.java
+++ b/src/main/java/com/zerozero/core/domain/record/StoreWithoutImages.java
@@ -1,0 +1,34 @@
+package com.zerozero.core.domain.record;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record StoreWithoutImages(
+    @Schema(description = "판매점 ID", example = "8e3006f4-3a16-11ef-9454-0242ac120002") UUID id,
+    @Schema(description = "카카오 ID", example = "25770215") String kakaoId,
+    @Schema(description = "판매점 이름", example = "제로 피자") String name,
+    @Schema(description = "판매 종류", example = "음식점 > 한식 > 육류,고기") String category,
+    @Schema(description = "전화번호", example = "02-525-6692") String phone,
+    @Schema(description = "판매점 주소", example = "서울특별시 서초구 서초동") String address,
+    @Schema(description = "판매점 도로명 주소", example = "서울특별시 서초구 서초대로50길 82 정원빌딩") String roadAddress,
+    @Schema(description = "판매점 x좌표(경도)", example = "127.01275515884753") String longitude,
+    @Schema(description = "판매점 y좌표(위도)", example = "37.49206032952165") String latitude,
+    @Schema(description = "제로음료 판매 여부", example = "true") Boolean status,
+    @Schema(description = "판매점 상세페이지 URL", example = "http://place.map.kakao.com/25770215") String placeUrl) {
+
+  public static StoreWithoutImages of(com.zerozero.core.domain.vo.Store store) {
+    return new StoreWithoutImages(
+        store.getId(),
+        store.getKakaoId(),
+        store.getName(),
+        store.getCategory(),
+        store.getPhone(),
+        store.getAddress(),
+        store.getRoadAddress(),
+        store.getLongitude(),
+        store.getLatitude(),
+        store.getStatus(),
+        store.getPlaceUrl()
+    );
+  }
+}

--- a/src/main/java/com/zerozero/store/presentation/SearchStoreController.java
+++ b/src/main/java/com/zerozero/store/presentation/SearchStoreController.java
@@ -1,10 +1,10 @@
 package com.zerozero.store.presentation;
 
-import  com.zerozero.configuration.swagger.ApiErrorCode;
+import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.domain.record.StoreWithoutImages;
 import com.zerozero.core.domain.vo.AccessToken;
-import com.zerozero.core.domain.vo.Store;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.store.application.SearchStoreUseCase;
 import com.zerozero.store.application.SearchStoreUseCase.SearchStoreErrorCode;
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -58,7 +59,11 @@ public class SearchStoreController {
             throw GlobalErrorCode.INTERNAL_ERROR.toException();
           });
     }
-    return ResponseEntity.ok(SearchStoreResponse.builder().stores(searchStoreResponse.getStores()).build());
+    return ResponseEntity.ok(SearchStoreResponse.builder()
+        .stores(searchStoreResponse.getStores().stream()
+            .map(StoreWithoutImages::of)
+            .collect(Collectors.toList()))
+        .build());
   }
 
   @ToString
@@ -71,7 +76,7 @@ public class SearchStoreController {
   public static class SearchStoreResponse extends BaseResponse<GlobalErrorCode> {
 
     @Schema(description = "판매점 목록")
-    private List<Store> stores;
+    private List<StoreWithoutImages> stores;
   }
 
   @ToString


### PR DESCRIPTION
가게제보 페이지에서 판매점 검색 시 이미지 배열 미노출 작업으로

이런 경우가 추후 또 발생할 수 있을 것 같아서

공통 레코드로 추출하여 구현하였습니다.

로컬에서 테스트 진행하였습니다.

close #92 