### PR TITLE
FIX: (#94) 메인페이지 판매점 조회에서 이미지가 null로 반환되는 문제를 해결한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/vo/Store.java
+++ b/src/main/java/com/zerozero/core/domain/vo/Store.java
@@ -99,7 +99,7 @@ public class Store extends ValueObject implements Serializable {
         .longitude(item.getX())
         .latitude(item.getY())
         .status(item.isStatus())
-        .images(null)
+        .images(item.getImages())
         .placeUrl(item.getPlaceUrl())
         .build();
   }

--- a/src/main/java/com/zerozero/external/kakao/search/dto/KeywordSearchResponse.java
+++ b/src/main/java/com/zerozero/external/kakao/search/dto/KeywordSearchResponse.java
@@ -1,6 +1,7 @@
 package com.zerozero.external.kakao.search.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerozero.core.domain.vo.Image;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
@@ -80,5 +81,7 @@ public class KeywordSearchResponse {
     private boolean status;
 
     private UUID storeId;
+
+    private Image[] images;
   }
 }

--- a/src/main/java/com/zerozero/store/application/SearchNearbyStoresUseCase.java
+++ b/src/main/java/com/zerozero/store/application/SearchNearbyStoresUseCase.java
@@ -95,10 +95,11 @@ public class SearchNearbyStoresUseCase implements BaseUseCase<SearchNearbyStores
       boolean isSelling = storeJPARepository.existsByNameAndLongitudeAndLatitudeAndStatusIsTrue(
           item.getPlaceName(), item.getX(), item.getY());
       if (isSelling) {
-        item.setStatus(true);
         Store store = storeJPARepository.findByNameAndLongitudeAndLatitudeAndStatusIsTrue(item.getPlaceName(),
             item.getX(), item.getY());
+        item.setStatus(true);
         item.setStoreId(store.getId());
+        item.setImages(store.getImages());
       }
     }).collect(Collectors.toList());
     return SearchNearbyStoresResponse.builder()

--- a/src/main/java/com/zerozero/store/presentation/SearchNearbyStoresController.java
+++ b/src/main/java/com/zerozero/store/presentation/SearchNearbyStoresController.java
@@ -3,8 +3,8 @@ package com.zerozero.store.presentation;
 import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.domain.record.Store;
 import com.zerozero.core.domain.vo.AccessToken;
-import com.zerozero.core.domain.vo.Store;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.store.application.SearchNearbyStoresUseCase;
 import com.zerozero.store.application.SearchNearbyStoresUseCase.SearchNearbyStoresErrorCode;
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,7 +61,11 @@ public class SearchNearbyStoresController {
             throw GlobalErrorCode.INTERNAL_ERROR.toException();
           });
     }
-    return ResponseEntity.ok(SearchNearbyStoresResponse.builder().stores(searchNearbyStoresResponse.getStores()).build());
+    return ResponseEntity.ok(SearchNearbyStoresResponse.builder()
+        .stores(searchNearbyStoresResponse.getStores().stream()
+            .map(Store::of)
+            .collect(Collectors.toList()))
+        .build());
   }
 
   @ToString


### PR DESCRIPTION
기존 카카오 API를 이용해 검색해온 item을 Store VO로 변환할 때 images를 null로 설정하는 문제가 있었습니다.

아마 images는 판매점 등록할 때 저장되기 때문에 카카오 API에서 조회할 때는 얻어오지 않으므로 null로 설정한 것으로 기억합니다.

하지만 이번 메인페이지 판매점 조회에서 이미지가 필요하므로 상기 문제 사항은 수정하였습니다.

close #94 