### PR TITLE
FIX: (#96) 리뷰 등록시 제로음료 타입의 중첩 JSON 구조를 변경한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/vo/Review.java
+++ b/src/main/java/com/zerozero/core/domain/vo/Review.java
@@ -1,10 +1,15 @@
 package com.zerozero.core.domain.vo;
 
 import com.zerozero.core.domain.shared.ValueObject;
+import com.zerozero.core.domain.vo.ZeroDrink.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,18 +38,8 @@ public class Review extends ValueObject implements Serializable {
   @Schema(description = "리뷰 내용", example = "제로 음료 판매중!")
   private String content;
 
-  @Schema(description = "제로 음료수 목록", example = "[\n" +
-      "    {\n" +
-      "      \"type\": \"COCA_COLA_ZERO\"\n" +
-      "    },\n" +
-      "    {\n" +
-      "      \"type\": \"PEPSI_ZERO\"\n" +
-      "    },\n" +
-      "    {\n" +
-      "      \"type\": \"SPRITE_ZERO\"\n" +
-      "    }\n" +
-      "]")
-  private ZeroDrink[] zeroDrinks;
+  @Schema(description = "제로 음료수 목록", example = "[\"COCA_COLA_ZERO\", \"PEPSI_ZERO\", \"SPRITE_ZERO\"]")
+  private List<Type> zeroDrinks;
 
   @Schema(description = "작성한 사용자 ID")
   private UUID userId;
@@ -56,7 +51,11 @@ public class Review extends ValueObject implements Serializable {
     return Review.builder()
         .id(review.getId())
         .content(review.getContent())
-        .zeroDrinks(review.getZeroDrinks())
+        .zeroDrinks(Optional.ofNullable(review.getZeroDrinks())
+            .map(zeroDrinks -> Arrays.stream(zeroDrinks)
+                .map(ZeroDrink::getType)
+                .collect(Collectors.toList()))
+            .orElse(null))
         .userId(review.getUserId())
         .build();
   }

--- a/src/main/java/com/zerozero/review/presentation/CreateStoreReviewController.java
+++ b/src/main/java/com/zerozero/review/presentation/CreateStoreReviewController.java
@@ -5,6 +5,7 @@ import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.ZeroDrink;
+import com.zerozero.core.domain.vo.ZeroDrink.Type;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.review.application.CreateStoreReviewUseCase;
 import com.zerozero.review.application.CreateStoreReviewUseCase.CreateStoreReviewErrorCode;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -50,7 +52,12 @@ public class CreateStoreReviewController {
         CreateStoreReviewUseCase.CreateStoreReviewRequest.builder()
             .storeId(storeId)
             .content(request.getContent())
-            .zeroDrinks(request.getZeroDrinks())
+            .zeroDrinks(Optional.ofNullable(request.getZeroDrinks())
+                .map(zeroDrinks -> zeroDrinks.stream().map(zeroDrink -> ZeroDrink.builder()
+                        .type(zeroDrink)
+                        .build())
+                    .toArray(ZeroDrink[]::new))
+                .orElse(null))
             .accessToken(accessToken)
             .build());
     if (createStoreReviewResponse == null || !createStoreReviewResponse.isSuccess()) {
@@ -86,17 +93,7 @@ public class CreateStoreReviewController {
     @Schema(description = "리뷰 내용", example = "제로콜라 판매 중!")
     private String content;
 
-    @Schema(description = "제로 음료수 목록", example = "[\n" +
-        "    {\n" +
-        "      \"type\": \"COCA_COLA_ZERO\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"PEPSI_ZERO\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"SPRITE_ZERO\"\n" +
-        "    }\n" +
-        "]")
-    private ZeroDrink[] zeroDrinks;
+    @Schema(description = "제로 음료수 목록", example = "[\"COCA_COLA_ZERO\", \"PEPSI_ZERO\", \"SPRITE_ZERO\"]")
+    private List<Type> zeroDrinks;
   }
 }

--- a/src/main/java/com/zerozero/review/presentation/UpdateStoreReviewController.java
+++ b/src/main/java/com/zerozero/review/presentation/UpdateStoreReviewController.java
@@ -5,6 +5,7 @@ import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.ZeroDrink;
+import com.zerozero.core.domain.vo.ZeroDrink.Type;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import com.zerozero.review.application.UpdateStoreReviewUseCase;
 import com.zerozero.review.application.UpdateStoreReviewUseCase.UpdateStoreReviewErrorCode;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -50,7 +52,12 @@ public class UpdateStoreReviewController {
         UpdateStoreReviewUseCase.UpdateStoreReviewRequest.builder()
             .reviewId(reviewId)
             .content(request.getContent())
-            .zeroDrinks(request.getZeroDrink())
+            .zeroDrinks(Optional.ofNullable(request.getZeroDrinks())
+                .map(zeroDrinks -> zeroDrinks.stream().map(zeroDrink -> ZeroDrink.builder()
+                        .type(zeroDrink)
+                        .build())
+                    .toArray(ZeroDrink[]::new))
+                .orElse(null))
             .accessToken(accessToken)
             .build());
     if (updateStoreReviewResponse == null || !updateStoreReviewResponse.isSuccess()) {
@@ -86,17 +93,7 @@ public class UpdateStoreReviewController {
     @Schema(description = "리뷰 내용", example = "제로콜라 판매 중!")
     private String content;
 
-    @Schema(description = "제로 음료수 목록", example = "[\n" +
-        "    {\n" +
-        "      \"type\": \"COCA_COLA_ZERO\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"PEPSI_ZERO\"\n" +
-        "    },\n" +
-        "    {\n" +
-        "      \"type\": \"SPRITE_ZERO\"\n" +
-        "    }\n" +
-        "]")
-    private ZeroDrink[] zeroDrink;
+    @Schema(description = "제로 음료수 목록", example = "[\"COCA_COLA_ZERO\", \"PEPSI_ZERO\", \"SPRITE_ZERO\"]")
+    private List<Type> zeroDrinks;
   }
 }


### PR DESCRIPTION
ZeroDrink VO에서 type 필드를 제거하고 Type Enum으로 변경하였습니다.

ZeroDrink VO 내 구조는 유지하되, Review VO의 ZeroDrink를 변경하였습니다.

추가로, 제로 음료 상위 3개를 노출하는 조건에 음료수의 수가 같을 경우 오름차순으로 정렬하게 하였습니다.

로컬에서 테스트 진행하였습니다.

close #96 