### PR TITLE
FEAT: (#98) 리뷰 노출 시 리뷰 생성 날짜를 같이 반환한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/vo/Review.java
+++ b/src/main/java/com/zerozero/core/domain/vo/Review.java
@@ -2,6 +2,7 @@ package com.zerozero.core.domain.vo;
 
 import com.zerozero.core.domain.shared.ValueObject;
 import com.zerozero.core.domain.vo.ZeroDrink.Type;
+import com.zerozero.core.util.TimeUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serial;
 import java.io.Serializable;
@@ -44,6 +45,9 @@ public class Review extends ValueObject implements Serializable {
   @Schema(description = "작성한 사용자 ID")
   private UUID userId;
 
+  @Schema(description = "리뷰 작성일자, YYYY.MM.DD", example = "2024.08.27")
+  private String createdAt;
+
   public static Review of(com.zerozero.core.domain.entity.Review review) {
     if (review == null) {
       return null;
@@ -57,6 +61,7 @@ public class Review extends ValueObject implements Serializable {
                 .collect(Collectors.toList()))
             .orElse(null))
         .userId(review.getUserId())
+        .createdAt(TimeUtil.toDotFormattedString(review.getCreatedAt().toLocalDate()))
         .build();
   }
 }

--- a/src/main/java/com/zerozero/core/util/TimeUtil.java
+++ b/src/main/java/com/zerozero/core/util/TimeUtil.java
@@ -1,0 +1,19 @@
+package com.zerozero.core.util;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimeUtil {
+
+  private static final DateTimeFormatter YYYY_MM_DD_DOT_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  public static String toDotFormattedString(LocalDate localDate) {
+    if (localDate == null) {
+      return null;
+    }
+    return localDate.format(YYYY_MM_DD_DOT_FORMATTER);
+  }
+}


### PR DESCRIPTION
리뷰 반환 시 VO를 반환하고 있으며 LocalDate의 format을 변경하기 위해

TimeUtil 유틸성 클래스를 만들어 추후 formatter가 추가될 수 있도록 만들었습니다.

프론트에서 yyyy.MM.dd 형식으로의 응답을 기대하여 위와 같은 형식으로 변경하였습니다.