### PR TITLE
FEAT: (#100) 판매점 리뷰 조회시 좋아요 개수와 여부를 반환한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/entity/Review.java
+++ b/src/main/java/com/zerozero/core/domain/entity/Review.java
@@ -42,7 +42,7 @@ public class Review extends BaseEntity {
         .build();
   }
 
-  public static List<Review> filter(List<Review> reviews, Filter filter, List<Integer> reviewCount) {
+  public static List<Review> filter(List<Review> reviews, Filter filter, List<Integer> reviewLikeCounts) {
     if (filter == null || reviews == null || reviews.isEmpty()) {
       return reviews;
     }
@@ -52,12 +52,12 @@ public class Review extends BaseEntity {
             Collectors.toList());
       }
       case RECOMMEND -> {
-        if (reviewCount == null || reviewCount.isEmpty() || reviewCount.size() != reviews.size()) {
+        if (reviewLikeCounts == null || reviewLikeCounts.isEmpty() || reviewLikeCounts.size() != reviews.size()) {
           return reviews;
         }
         return IntStream.range(0, reviews.size())
             .boxed()
-            .sorted((i, j) -> reviewCount.get(j).compareTo(reviewCount.get(i)))
+            .sorted((i, j) -> reviewLikeCounts.get(j).compareTo(reviewLikeCounts.get(i)))
             .map(reviews::get)
             .collect(Collectors.toList());
       }

--- a/src/main/java/com/zerozero/core/domain/infra/repository/ReviewLikeJPARepository.java
+++ b/src/main/java/com/zerozero/core/domain/infra/repository/ReviewLikeJPARepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewLikeJPARepository extends JpaRepository<ReviewLike, Long> {
 
-  ReviewLike findByReviewIdAndUserId(UUID reviewId, UUID userId);
+  ReviewLike findByReviewIdAndUserIdAndDeleted(UUID reviewId, UUID userId, Boolean deleted);
 
-  Integer countByReviewId(UUID reviewId);
+  Integer countByReviewIdAndDeleted(UUID reviewId, Boolean deleted);
+
+  Boolean existsByReviewIdAndUserIdAndDeleted(UUID reviewId, UUID userId, Boolean deleted);
 }

--- a/src/main/java/com/zerozero/review/application/LikeStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/LikeStoreReviewUseCase.java
@@ -78,7 +78,7 @@ public class LikeStoreReviewUseCase implements BaseUseCase<LikeStoreReviewReques
           .errorCode(LikeStoreReviewErrorCode.NOT_EXIST_DELETABLE_REVIEW)
           .build();
     }
-    ReviewLike reviewLike = reviewLikeJPARepository.findByReviewIdAndUserId(review.getId(), user.getId());
+    ReviewLike reviewLike = reviewLikeJPARepository.findByReviewIdAndUserIdAndDeleted(review.getId(), user.getId(), false);
     if (reviewLike == null) {
       reviewLike = new ReviewLike(review, user);
       reviewLikeJPARepository.save(reviewLike);

--- a/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
+++ b/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
@@ -130,10 +130,13 @@ public class ReadStoreInfoController {
     @Schema(description = "제로 음료수 순위")
     private List<Type> zeroDrinks;
 
-    record Review(com.zerozero.core.domain.vo.Review review, User user) {
+    record Review(com.zerozero.core.domain.vo.Review review, User user, Integer likeCount, Boolean isLiked) {
 
       public static Review of(ReadStoreReviewResponse.Review review) {
-        return new Review(review.getReview(), review.getUser());
+        if (review == null) {
+          return null;
+        }
+        return new Review(review.getReview(), review.getUser(), review.getLikeCount(), review.getIsLiked());
       }
     }
   }


### PR DESCRIPTION
판매점 리뷰 조회시 좋아요 개수와 좋아요 여부를 반환하는 작업으로

좋아요 개수는 `likeCount`, 좋아요 여부는 `isLiked 로 변수명 설정하였습니다.

현재 좋아요 삭제는 논리적 삭제를 적용하고 있는데 jpa에서 deleted 조건을 추가하지 않아서 추가하였습니다.

로컬에서 테스트 진행하였습니다.