### PR TITLE
FIX: (#103) 실시간 위치를 통해 판매점을 조회할 때 반경 100m를 1km로 변경한다

### DIFF
--- a/src/main/java/com/zerozero/store/application/ReadNearbyStoresUseCase.java
+++ b/src/main/java/com/zerozero/store/application/ReadNearbyStoresUseCase.java
@@ -40,7 +40,7 @@ public class ReadNearbyStoresUseCase implements BaseUseCase<ReadNearbyStoresRequ
 
   private final StoreMongoRepository storeMongoRepository;
 
-  public static final Double DEFAULT_RADIUS = 100.0;
+  public static final Double DEFAULT_RADIUS = 1000.0;
 
   @Override
   public ReadNearbyStoresResponse execute(ReadNearbyStoresRequest request) {


### PR DESCRIPTION
사용자의 실시간 위치를 기반으로 등록된 판매점을 조회하는 로직에서 변경된 사항으로

기존 반경 100m 내 등록된 판매점을 조회하는 것을

1km로 변경하였습니다.

로컬에서 테스트 진행하였습니다.