### PR TITLE
FIX: (#104) 실시간 위치를 통해 판매점을 조회할 때 상태 값을 반환한다

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,7 +7,7 @@ services:
     image: mysql:8.0.23
     platform: linux/amd64
     ports:
-      - '3306:3306'
+      - '3307:3306'
     restart: always
     volumes:
       - ./docker/mysql/db:/var/lib/mysql

--- a/src/main/java/com/zerozero/core/domain/infra/mongodb/store/Store.java
+++ b/src/main/java/com/zerozero/core/domain/infra/mongodb/store/Store.java
@@ -38,6 +38,9 @@ public class Store {
 
   private String latitude;
 
+  @Builder.Default
+  private Boolean status = true;
+
   private GeoJsonPoint location;
 
   private String placeUrl;


### PR DESCRIPTION
판매점이 등록될 때 실시간 위치를 통해 조회하는 DB는 Mongo를 사용하는데

이때 비동기 처리를 위해서 rabbitmq를 이용하여 db에 저장하고 있습니다.

Mongo DB에 저장되는 판매점은 모두 제로 음료를 판매하는 판매점이기 때문에

status를 true로 기본값을 설정하였습니다.

로컬에서 테스트 진행하였습니다.

-- 
원래 도커를 통해 MySQL 3306 포트를 띄워 사용하였고, 로컬에서 3306 포트를 사용하지 않았는데

학교 수업에서 로컬 MySQL을 3306 포트에 띄워 사용하여 포트 충돌로 인해

docker 포트를 3307로 변경하였습니다.