### PR TITLE
Fix: (#107) CORS 설정에서 Access-Control-Allow-Origin에 API 도메인을 추가한다

### DIFF
--- a/src/main/java/com/zerozero/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerozero/configuration/security/SecurityConfiguration.java
@@ -38,7 +38,7 @@ public class SecurityConfiguration {
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration config = new CorsConfiguration();
-    config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://d1tengjnya43h9.cloudfront.net/"));
+    config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://d1tengjnya43h9.cloudfront.net/", "https://api.zerozero.today/"));
     config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
     config.setAllowedHeaders(Arrays.asList("*"));
     config.setAllowCredentials(true);


### PR DESCRIPTION
API 서버 도메인에서 CORS 에러 이슈 대응 작업으로

API 도메인을 CORS Access-Control-Allow-Origin에 API 도메인을 추가하였습니다.