### PR TITLE
FEAT: (#109) Swagger에서 백엔드 API 서버 도메인을 이용해 HTTPS 설정한다

### DIFF
--- a/src/main/java/com/zerozero/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/com/zerozero/configuration/swagger/SwaggerConfiguration.java
@@ -4,6 +4,7 @@ import com.zerozero.core.exception.error.BaseErrorCode;
 import com.zerozero.core.presentation.ErrorResponse;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -32,7 +33,7 @@ import org.springframework.web.method.HandlerMethod;
 @OpenAPIDefinition(
     info = @Info(title = "Zerozero API",
         description = "Zerozero : API 명세서",
-        version = "v1.0.0"))
+        version = "v1.0.0"), servers = {@Server(url = "${springdoc.server-url}", description = "Default Server URL")})
 @Configuration
 public class SwaggerConfiguration {
 


### PR DESCRIPTION
Swagger에서 HTTPS 백엔드 API 도메인이 되지 않은 이슈 대응 작업으로

서버에 백엔드 도메인을 지정해 작업을 하였습니다.

application.yml 파일 변경점 존재합니다.