### PR TITLE
FIX: (#119) 리뷰 애그리거트에서 리뷰 엔티티와 좋아요 엔티티를 일대다 직접 참조로 변경한다

### DIFF
--- a/mysql/0_review_like.sql
+++ b/mysql/0_review_like.sql
@@ -10,3 +10,6 @@ CREATE TABLE IF NOT EXISTS review_like
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci COMMENT '리뷰 좋아요';
+
+ALTER TABLE review_like
+    ADD FOREIGN KEY (review_id) REFERENCES review (id) ON DELETE CASCADE;

--- a/src/main/java/com/zerozero/core/domain/entity/Review.java
+++ b/src/main/java/com/zerozero/core/domain/entity/Review.java
@@ -2,8 +2,12 @@ package com.zerozero.core.domain.entity;
 
 import com.zerozero.core.domain.shared.BaseEntity;
 import com.zerozero.core.domain.vo.ZeroDrink;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -32,6 +36,10 @@ public class Review extends BaseEntity {
   private UUID userId;
 
   private UUID storeId;
+
+  @OneToMany(cascade = CascadeType.ALL)
+  @JoinColumn(name = "reviewId")
+  private List<ReviewLike> reviewLikes = new ArrayList<>();
 
   public static Review of(String content, ZeroDrink[] zeroDrinks, User user, Store store) {
     return Review.builder()
@@ -69,6 +77,10 @@ public class Review extends BaseEntity {
 
   public boolean hasUserReviewed(User user) {
     return this.userId.equals(user.getId());
+  }
+
+  public void deleted(boolean deleted) {
+    setDeleted(deleted);
   }
 
   public enum Filter {

--- a/src/main/java/com/zerozero/review/application/DeleteStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/DeleteStoreReviewUseCase.java
@@ -6,18 +6,25 @@ import com.zerozero.core.application.BaseUseCase;
 import com.zerozero.core.domain.entity.Review;
 import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.domain.infra.repository.ReviewJPARepository;
+import com.zerozero.core.domain.infra.repository.ReviewLikeJPARepository;
 import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
 import com.zerozero.review.application.DeleteStoreReviewUseCase.DeleteStoreReviewRequest;
 import com.zerozero.review.application.DeleteStoreReviewUseCase.DeleteStoreReviewResponse;
-import lombok.*;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Log4j2
 @Service
@@ -26,6 +33,8 @@ import java.util.UUID;
 public class DeleteStoreReviewUseCase implements BaseUseCase<DeleteStoreReviewRequest, DeleteStoreReviewResponse> {
 
   private final ReviewJPARepository reviewJPARepository;
+
+  private final ReviewLikeJPARepository reviewLikeJPARepository;
 
   @Override
   public DeleteStoreReviewResponse execute(DeleteStoreReviewRequest request) {
@@ -52,7 +61,8 @@ public class DeleteStoreReviewUseCase implements BaseUseCase<DeleteStoreReviewRe
           .errorCode(DeleteStoreReviewErrorCode.USER_VALIDATION_FAILED)
           .build();
     }
-    review.setDeleted(true);
+    reviewLikeJPARepository.deleteAll(review.getReviewLikes());
+    review.deleted(true);
     return DeleteStoreReviewResponse.builder().build();
   }
 

--- a/src/main/java/com/zerozero/review/application/LikeStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/LikeStoreReviewUseCase.java
@@ -12,14 +12,20 @@ import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
 import com.zerozero.review.application.LikeStoreReviewUseCase.LikeStoreReviewRequest;
 import com.zerozero.review.application.LikeStoreReviewUseCase.LikeStoreReviewResponse;
-import lombok.*;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Log4j2
 @Service
@@ -53,8 +59,9 @@ public class LikeStoreReviewUseCase implements BaseUseCase<LikeStoreReviewReques
     if (reviewLike == null) {
       reviewLike = new ReviewLike(review, user);
       reviewLikeJPARepository.save(reviewLike);
-    } else
-      reviewLike.setDeleted(!reviewLike.getDeleted());
+    } else {
+      reviewLikeJPARepository.delete(reviewLike);
+    }
     return LikeStoreReviewResponse.builder().build();
   }
 

--- a/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
+++ b/src/main/java/com/zerozero/store/presentation/ReadStoreInfoController.java
@@ -1,10 +1,12 @@
 package com.zerozero.store.presentation;
 
+import com.zerozero.configuration.argumentresolver.LoginUser;
 import com.zerozero.configuration.interceptor.Authorization;
 import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.entity.Review.Filter;
+import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.domain.vo.Store;
 import com.zerozero.core.domain.vo.ZeroDrink.Type;
 import com.zerozero.core.exception.error.GlobalErrorCode;
@@ -14,6 +16,7 @@ import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewRes
 import com.zerozero.store.application.ReadStoreInfoUseCase;
 import com.zerozero.store.application.ReadStoreInfoUseCase.ReadStoreInfoErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.*;
@@ -43,7 +46,7 @@ public class ReadStoreInfoController {
   @ApiErrorCode({GlobalErrorCode.class, ReadStoreInfoErrorCode.class})
   @Authorization
   @GetMapping("/store")
-  public ResponseEntity<ReadStoreInfoResponse> readStoreInfo(@ParameterObject ReadStoreInfoRequest request) {
+  public ResponseEntity<ReadStoreInfoResponse> readStoreInfo(@ParameterObject ReadStoreInfoRequest request, @Parameter(hidden = true) @LoginUser User user) {
     ReadStoreInfoUseCase.ReadStoreInfoResponse readStoreInfoResponse = readStoreInfoUseCase.execute(
         ReadStoreInfoUseCase.ReadStoreInfoRequest.builder()
             .storeId(request.getStoreId())
@@ -57,10 +60,12 @@ public class ReadStoreInfoController {
             throw GlobalErrorCode.INTERNAL_ERROR.toException();
           });
     }
-    ReadStoreReviewResponse readStoreReviewResponse = readStoreReviewUseCase.execute(ReadStoreReviewRequest.builder()
-        .storeId(request.getStoreId())
-        .filter(request.getFilter())
-        .build());
+    ReadStoreReviewResponse readStoreReviewResponse = readStoreReviewUseCase.execute(
+        ReadStoreReviewRequest.builder()
+            .storeId(request.getStoreId())
+            .filter(request.getFilter())
+            .user(user)
+            .build());
     if (readStoreReviewResponse == null || !readStoreReviewResponse.isSuccess()) {
       Optional.ofNullable(readStoreReviewResponse)
           .map(BaseResponse::getErrorCode)


### PR DESCRIPTION
## AS-IS
- 리뷰와 좋아요는 간접 참조 관계
- 리뷰, 좋아요 모두 논리적 삭제

## TO-BE
- 같은 애그리거트에 포함시켜서 리뷰와 좋아요는 동기화를 위한 직접 참조로 변경
- 일대다 단방향으로 매핑
  - 양방향 매핑시 순환참조와 각 테이블을 서로 관리하는 문제 발생
  - 리뷰를 통해 좋아요 수를 집계하는 등의 작업이 필요해서 단방향으로 처리
- 리뷰 : 논리적 삭제, 좋아요 : 물리적 삭제로 변경
  - 리뷰는 추후 삭제되더라도 DB에서 내역 조회 등 필요할 수 있지만, 좋아요는 그렇지 않을 거라 판단

## 추후 진행 사항
- 좋아요 동시성 문제 고려해야함.

이외 #115 작업에서 빠진 부분이 있어 수정 커밋 추가
close #119 

