### PR TITLE
FIX: (#121) 판매점 리뷰 조회 성능 향상을 위한 쿼리를 최적화한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QueryDSL ###
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 jar {
@@ -55,4 +60,12 @@ jar {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+clean {
+    delete file('src/main/generated')
 }

--- a/src/main/java/com/zerozero/configuration/QueryDSLConfiguration.java
+++ b/src/main/java/com/zerozero/configuration/QueryDSLConfiguration.java
@@ -1,0 +1,19 @@
+package com.zerozero.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDSLConfiguration {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/zerozero/core/domain/infra/querydsl/ReviewQueryRepository.java
+++ b/src/main/java/com/zerozero/core/domain/infra/querydsl/ReviewQueryRepository.java
@@ -1,0 +1,48 @@
+package com.zerozero.core.domain.infra.querydsl;
+
+import static com.zerozero.core.domain.entity.QReview.review;
+import static com.zerozero.core.domain.entity.QReviewLike.reviewLike;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerozero.core.domain.entity.Review;
+import com.zerozero.core.domain.entity.Review.Filter;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<Review> findByStoreIdAndFilter(UUID storeId, Filter filter) {
+    JPAQuery<Review> query = queryFactory.selectFrom(review)
+        .leftJoin(review.reviewLikes, reviewLike)
+        .fetchJoin()
+        .where(
+            eqStoreId(storeId),
+            isDeleted(false)
+        )
+        .distinct();
+
+    if (filter == null || filter == Filter.RECENT) {
+      query.orderBy(review.createdAt.desc());
+    } else if (filter == Filter.RECOMMEND) {
+      query.orderBy(review.reviewLikes.size().desc(), review.createdAt.desc());
+    }
+
+    return query.fetch();
+  }
+
+  private BooleanExpression eqStoreId(UUID storeId) {
+    return review.storeId.eq(storeId);
+  }
+
+  private BooleanExpression isDeleted(boolean deleted) {
+    return review.deleted.eq(deleted);
+  }
+}

--- a/src/main/java/com/zerozero/review/application/ReadStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/ReadStoreReviewUseCase.java
@@ -6,25 +6,26 @@ import com.zerozero.core.application.BaseUseCase;
 import com.zerozero.core.domain.entity.Review;
 import com.zerozero.core.domain.entity.Review.Filter;
 import com.zerozero.core.domain.entity.User;
-import com.zerozero.core.domain.infra.repository.ReviewJPARepository;
-import com.zerozero.core.domain.infra.repository.ReviewLikeJPARepository;
-import com.zerozero.core.domain.infra.repository.UserJPARepository;
+import com.zerozero.core.domain.infra.querydsl.ReviewQueryRepository;
 import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
 import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewRequest;
 import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewResponse;
-import lombok.*;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Log4j2
 @Service
@@ -32,11 +33,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ReadStoreReviewUseCase implements BaseUseCase<ReadStoreReviewRequest, ReadStoreReviewResponse> {
 
-  private final ReviewJPARepository reviewJPARepository;
-
-  private final ReviewLikeJPARepository reviewLikeJPARepository;
-
-  private final UserJPARepository userJPARepository;
+  private final ReviewQueryRepository reviewQueryRepository;
 
   @Override
   public ReadStoreReviewResponse execute(ReadStoreReviewRequest request) {
@@ -48,33 +45,23 @@ public class ReadStoreReviewUseCase implements BaseUseCase<ReadStoreReviewReques
           .build();
     }
     User user = request.getUser();
-    List<Review> reviews = reviewJPARepository.findAllByStoreIdAndDeleted(request.getStoreId(), false);
-    List<Integer> reviewLikeCounts = reviews.stream()
-        .map(review -> Optional.ofNullable(
-            reviewLikeJPARepository.countByReviewIdAndDeleted(review.getId(), false)).orElse(0))
-        .collect(Collectors.toList());
-    com.zerozero.core.domain.vo.Review[] reviewsVO = Review.filter(reviews, request.getFilter(), reviewLikeCounts)
-        .stream().map(com.zerozero.core.domain.vo.Review::of)
-        .toArray(com.zerozero.core.domain.vo.Review[]::new);
-    return ReadStoreReviewResponse.builder().reviews(convertReviewResponse(reviewsVO, user)).build();
+    List<Review> reviews = reviewQueryRepository.findByStoreIdAndFilter(request.getStoreId(), request.getFilter());
+    return ReadStoreReviewResponse.builder().reviews(convertReviewResponse(reviews, user)).build();
   }
 
-  private ReadStoreReviewResponse.Review[] convertReviewResponse(com.zerozero.core.domain.vo.Review[] reviewsVO, User user) {
-    if (reviewsVO == null || user == null) {
+  private ReadStoreReviewResponse.Review[] convertReviewResponse(List<Review> reviews, User user) {
+    if (reviews.isEmpty() || user == null) {
       return null;
     }
-    return Arrays.stream(reviewsVO).map(review ->
-        ReadStoreReviewResponse.Review.builder()
-            .review(review)
-            .user(
-                com.zerozero.core.domain.vo.User.of(userJPARepository.findById(review.getUserId()).orElse(null)))
-            .likeCount(Optional.ofNullable(
-                reviewLikeJPARepository.countByReviewIdAndDeleted(review.getId(), false)).orElse(0))
-            .isLiked(Optional.ofNullable(
-                reviewLikeJPARepository.existsByReviewIdAndUserIdAndDeleted(review.getId(),
-                    user.getId(), false)).orElse(false))
-            .build()
-    ).toArray(ReadStoreReviewResponse.Review[]::new);
+    return reviews.stream()
+        .map(review -> ReadStoreReviewResponse.Review.builder()
+            .review(com.zerozero.core.domain.vo.Review.of(review))
+            .user(com.zerozero.core.domain.vo.User.of(user))
+            .likeCount(review.getReviewLikes().size())
+            .isLiked(review.getReviewLikes().stream()
+                .anyMatch(like -> user.getId().equals(like.getUserId())))
+            .build())
+        .toArray(ReadStoreReviewResponse.Review[]::new);
   }
 
   @Getter


### PR DESCRIPTION
AS-IS
```java
List<Review> reviews = reviewJPARepository.findAllByStoreIdAndDeleted(request.getStoreId(), false);
    List<Integer> reviewLikeCounts = reviews.stream()
        .map(review -> Optional.ofNullable(
            reviewLikeJPARepository.countByReviewIdAndDeleted(review.getId(), false)).orElse(0))
        .collect(Collectors.toList());
   ...
  }

  private ReadStoreReviewResponse.Review[] convertReviewResponse(com.zerozero.core.domain.vo.Review[] reviewsVO, User user) {
    if (reviewsVO == null || user == null) {
    return Arrays.stream(reviewsVO).map(review ->
        ReadStoreReviewResponse.Review.builder()
            .review(review)
            .user(
                com.zerozero.core.domain.vo.User.of(userJPARepository.findById(review.getUserId()).orElse(null)))
            .likeCount(Optional.ofNullable(
                reviewLikeJPARepository.countByReviewIdAndDeleted(review.getId(), false)).orElse(0))
            .isLiked(Optional.ofNullable(
                reviewLikeJPARepository.existsByReviewIdAndUserIdAndDeleted(review.getId(),
                    user.getId(), false)).orElse(false))
            .build()
```

최대 쿼리 발생 개수 : 
- 판매점 리뷰 조회 시 + 1
- 각 리뷰의 좋아요 개수 조회 시 + N (좋아요 개수)
- 좋아요 여부 +N (좋아요 개수)

TO-BE
- FetchJoin을 이용해서 최대 1번

- JPA Specification와 QueryDSL을 비교했었는데, QueryDSL이 컴파일 시점에서 에러를 반환하고, 한 번 적용해보고 싶어 사용했습니다.
- 좋아요 개수가 같을 떄, 최신 순일 경우 우선 반환하게 변경하였습니다.

