### PR TITLE
FIX: (#130) 리뷰 조회 시 작성자 정보가 잘못 반영되는 로직을 수정한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/entity/Review.java
+++ b/src/main/java/com/zerozero/core/domain/entity/Review.java
@@ -8,11 +8,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -48,31 +45,6 @@ public class Review extends BaseEntity {
         .storeId(store.getId())
         .userId(user.getId())
         .build();
-  }
-
-  public static List<Review> filter(List<Review> reviews, Filter filter, List<Integer> reviewLikeCounts) {
-    if (filter == null || reviews == null || reviews.isEmpty()) {
-      return reviews;
-    }
-    switch (filter) {
-      case RECENT -> {
-        return reviews.stream().sorted(Comparator.comparing(Review::getCreatedAt).reversed()).collect(
-            Collectors.toList());
-      }
-      case RECOMMEND -> {
-        if (reviewLikeCounts == null || reviewLikeCounts.isEmpty() || reviewLikeCounts.size() != reviews.size()) {
-          return reviews;
-        }
-        return IntStream.range(0, reviews.size())
-            .boxed()
-            .sorted((i, j) -> reviewLikeCounts.get(j).compareTo(reviewLikeCounts.get(i)))
-            .map(reviews::get)
-            .collect(Collectors.toList());
-      }
-      default -> {
-        return reviews;
-      }
-    }
   }
 
   public boolean hasUserReviewed(User user) {

--- a/src/main/java/com/zerozero/core/domain/infra/repository/UserJPARepository.java
+++ b/src/main/java/com/zerozero/core/domain/infra/repository/UserJPARepository.java
@@ -1,10 +1,13 @@
 package com.zerozero.core.domain.infra.repository;
 
 import com.zerozero.core.domain.entity.User;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJPARepository extends JpaRepository<User, UUID> {
 
   User findByEmail(String email);
+
+  List<User> findAllByIdInAndDeleted(List<UUID> userIds, boolean deleted);
 }

--- a/src/main/java/com/zerozero/review/application/ReadStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/application/ReadStoreReviewUseCase.java
@@ -7,12 +7,15 @@ import com.zerozero.core.domain.entity.Review;
 import com.zerozero.core.domain.entity.Review.Filter;
 import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.domain.infra.querydsl.ReviewQueryRepository;
+import com.zerozero.core.domain.infra.repository.UserJPARepository;
 import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
 import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewRequest;
 import com.zerozero.review.application.ReadStoreReviewUseCase.ReadStoreReviewResponse;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +38,8 @@ public class ReadStoreReviewUseCase implements BaseUseCase<ReadStoreReviewReques
 
   private final ReviewQueryRepository reviewQueryRepository;
 
+  private final UserJPARepository userJPARepository;
+
   @Override
   public ReadStoreReviewResponse execute(ReadStoreReviewRequest request) {
     if (request == null || !request.isValid()) {
@@ -46,22 +51,36 @@ public class ReadStoreReviewUseCase implements BaseUseCase<ReadStoreReviewReques
     }
     User user = request.getUser();
     List<Review> reviews = reviewQueryRepository.findByStoreIdAndFilter(request.getStoreId(), request.getFilter());
-    return ReadStoreReviewResponse.builder().reviews(convertReviewResponse(reviews, user)).build();
+    Map<UUID, User> reviewAuthorMap = getReviewAuthors(reviews);
+    return ReadStoreReviewResponse.builder().reviews(convertReviewResponse(user, reviews, reviewAuthorMap)).build();
   }
 
-  private ReadStoreReviewResponse.Review[] convertReviewResponse(List<Review> reviews, User user) {
-    if (reviews.isEmpty() || user == null) {
+  private ReadStoreReviewResponse.Review[] convertReviewResponse(User user, List<Review> reviews, Map<UUID, User> reviewAuthorMap) {
+    if (user == null || reviews.isEmpty() || reviewAuthorMap.isEmpty()) {
       return null;
     }
     return reviews.stream()
-        .map(review -> ReadStoreReviewResponse.Review.builder()
-            .review(com.zerozero.core.domain.vo.Review.of(review))
-            .user(com.zerozero.core.domain.vo.User.of(user))
-            .likeCount(review.getReviewLikes().size())
-            .isLiked(review.getReviewLikes().stream()
-                .anyMatch(like -> user.getId().equals(like.getUserId())))
-            .build())
+        .map(review -> {
+          User reviewAuthor = reviewAuthorMap.get(review.getUserId());
+          return ReadStoreReviewResponse.Review.builder()
+              .review(com.zerozero.core.domain.vo.Review.of(review))
+              .user(com.zerozero.core.domain.vo.User.of(reviewAuthor))
+              .likeCount(review.getReviewLikes().size())
+              .isLiked(review.getReviewLikes().stream()
+                  .anyMatch(like -> user.getId().equals(like.getUserId())))
+              .build();
+        })
         .toArray(ReadStoreReviewResponse.Review[]::new);
+  }
+
+  private Map<UUID, User> getReviewAuthors(List<Review> reviews) {
+    return userJPARepository.findAllByIdInAndDeleted(
+        reviews.stream()
+            .map(Review::getUserId)
+            .distinct()
+            .collect(Collectors.toList()),
+        false
+    ).stream().collect(Collectors.toMap(User::getId, reviewAuthor -> reviewAuthor));
   }
 
   @Getter


### PR DESCRIPTION
## AS-IS
- 리뷰 조회 시 리뷰 작성자가 아닌, 판매점 조회자의 정보가 노출

## TO-BE
- 리뷰의 사용자 ID를 IN 절을 사용해 하나의 쿼리로 호출 및 애플리케이션 단에서 처리
- Map을 이용해서 O(1) 시간복잡도로 구현 (<-> list.contains() : O(N))
