### PR TITLE
FIX: (#126) RefreshToken의 경우 Redis를 통해 관리한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -45,6 +45,16 @@ services:
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
 
+  redis:
+    container_name: zerozero_redis
+    image: redis:6.0.9
+    ports:
+      - '6379:6379'
+    restart: always
+    volumes:
+      - ./docker/redis/data:/data
+      - ./docker/redis/conf/redis.conf:/usr/local/etc/redis/redis.conf
+
 volumes:
   mongo-data:
   rabbitmq-data:

--- a/src/main/java/com/zerozero/auth/application/HandleOAuthLoginUseCase.java
+++ b/src/main/java/com/zerozero/auth/application/HandleOAuthLoginUseCase.java
@@ -14,7 +14,7 @@ import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.application.BaseUseCase;
 import com.zerozero.core.domain.entity.Status;
 import com.zerozero.core.domain.entity.User;
-import com.zerozero.core.domain.infra.repository.RefreshTokenJPARepository;
+import com.zerozero.core.domain.infra.repository.RefreshTokenRepository;
 import com.zerozero.core.domain.infra.repository.UserJPARepository;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.RefreshToken;
@@ -47,7 +47,7 @@ public class HandleOAuthLoginUseCase implements BaseUseCase<HandleOAuthLoginRequ
 
   private final JwtUtil jwtUtil;
 
-  private final RefreshTokenJPARepository refreshTokenJPARepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   @Override
   public HandleOAuthLoginResponse execute(HandleOAuthLoginRequest request) {
@@ -89,7 +89,7 @@ public class HandleOAuthLoginUseCase implements BaseUseCase<HandleOAuthLoginRequ
   private HandleOAuthLoginResponse generateAndBuildResponse(User user) {
     AccessToken accessToken = jwtUtil.generateAccessToken(user);
     RefreshToken refreshToken = jwtUtil.generateRefreshToken(user);
-    refreshTokenJPARepository.save(refreshToken.toEntity());
+    refreshTokenRepository.save(refreshToken.toEntity(user.getId()));
 
     return HandleOAuthLoginResponse.builder()
         .user(com.zerozero.core.domain.vo.User.of(user))

--- a/src/main/java/com/zerozero/auth/application/RefreshUserTokenUseCase.java
+++ b/src/main/java/com/zerozero/auth/application/RefreshUserTokenUseCase.java
@@ -7,7 +7,7 @@ import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.application.BaseUseCase;
 import com.zerozero.core.domain.entity.User;
-import com.zerozero.core.domain.infra.repository.RefreshTokenJPARepository;
+import com.zerozero.core.domain.infra.repository.RefreshTokenRepository;
 import com.zerozero.core.domain.infra.repository.UserJPARepository;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.RefreshToken;
@@ -39,7 +39,7 @@ public class RefreshUserTokenUseCase implements BaseUseCase<RefreshUserTokenRequ
 
   private final UserJPARepository userJPARepository;
 
-  private final RefreshTokenJPARepository refreshTokenJPARepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   @Override
   public RefreshUserTokenResponse execute(RefreshUserTokenRequest request) {
@@ -62,7 +62,7 @@ public class RefreshUserTokenUseCase implements BaseUseCase<RefreshUserTokenRequ
       return RefreshUserTokenResponse.builder().success(false)
           .errorCode(RefreshUserTokenErrorCode.NOT_EXIST_USER).build();
     }
-    com.zerozero.core.domain.entity.RefreshToken alreadyExistRefreshToken = refreshTokenJPARepository.findByUserId(user.getId());
+    com.zerozero.core.domain.entity.RefreshToken alreadyExistRefreshToken = refreshTokenRepository.findById(user.getId()).orElse(null);
     if (alreadyExistRefreshToken == null) {
       log.error("[RefreshUserTokenUseCase] Refresh token not exist");
       return RefreshUserTokenResponse.builder().success(false)

--- a/src/main/java/com/zerozero/auth/presentation/RefreshUserTokenController.java
+++ b/src/main/java/com/zerozero/auth/presentation/RefreshUserTokenController.java
@@ -5,25 +5,27 @@ import com.zerozero.auth.application.RefreshUserTokenUseCase.RefreshUserTokenErr
 import com.zerozero.auth.application.RefreshUserTokenUseCase.RefreshUserTokenResponse.Tokens;
 import com.zerozero.auth.presentation.RefreshUserTokenController.RefreshUserTokenResponse.Token;
 import com.zerozero.configuration.swagger.ApiErrorCode;
+import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.domain.vo.AccessToken;
 import com.zerozero.core.domain.vo.RefreshToken;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,11 +41,11 @@ public class RefreshUserTokenController {
       operationId = "/refresh/token"
   )
   @ApiErrorCode({GlobalErrorCode.class, RefreshUserTokenErrorCode.class})
-  @PostMapping("/refresh/token")
-  public ResponseEntity<RefreshUserTokenResponse> refreshUserToken(@Parameter(hidden = true) RefreshToken refreshToken) {
+  @GetMapping("/refresh/token")
+  public ResponseEntity<RefreshUserTokenResponse> refreshUserToken(@ParameterObject RefreshUserTokenRequest refreshUserTokenRequest) {
     RefreshUserTokenUseCase.RefreshUserTokenResponse refreshUserTokenResponse = refreshUserTokenUseCase.execute(
         RefreshUserTokenUseCase.RefreshUserTokenRequest.builder()
-            .refreshToken(refreshToken)
+            .refreshToken(RefreshToken.of(refreshUserTokenRequest.getRefreshToken()))
             .build());
     if (refreshUserTokenResponse == null || !refreshUserTokenResponse.isSuccess()) {
       Optional.ofNullable(refreshUserTokenResponse)
@@ -79,5 +81,18 @@ public class RefreshUserTokenController {
 
     record Token(String accessToken, String refreshToken) {
     }
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  @Schema(description = "토큰 재발급 요청")
+  public static class RefreshUserTokenRequest implements BaseRequest {
+
+    @Schema(description = "리프레시 토큰")
+    private String refreshToken;
   }
 }

--- a/src/main/java/com/zerozero/core/domain/entity/RefreshToken.java
+++ b/src/main/java/com/zerozero/core/domain/entity/RefreshToken.java
@@ -1,29 +1,18 @@
 package com.zerozero.core.domain.entity;
 
-import com.zerozero.core.domain.shared.BaseAutoIncrementEntity;
-import jakarta.persistence.Entity;
 import java.util.UUID;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
-@SuperBuilder
-public class RefreshToken extends BaseAutoIncrementEntity {
+@Builder
+@RedisHash(value = "refreshToken", timeToLive = 604_800_000)
+public class RefreshToken {
 
-  private String refreshToken;
-
+  @Id
   private UUID userId;
 
-  public RefreshToken update(String refreshToken) {
-    this.refreshToken = refreshToken;
-    return this;
-  }
+  private String refreshToken;
 }

--- a/src/main/java/com/zerozero/core/domain/infra/repository/RefreshTokenJPARepository.java
+++ b/src/main/java/com/zerozero/core/domain/infra/repository/RefreshTokenJPARepository.java
@@ -1,9 +1,0 @@
-package com.zerozero.core.domain.infra.repository;
-
-import com.zerozero.core.domain.entity.RefreshToken;
-import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RefreshTokenJPARepository extends JpaRepository<RefreshToken, Long> {
-  RefreshToken findByUserId(UUID userId);
-}

--- a/src/main/java/com/zerozero/core/domain/infra/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/zerozero/core/domain/infra/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.zerozero.core.domain.infra.repository;
+
+import com.zerozero.core.domain.entity.RefreshToken;
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, UUID> {
+}

--- a/src/main/java/com/zerozero/core/domain/vo/RefreshToken.java
+++ b/src/main/java/com/zerozero/core/domain/vo/RefreshToken.java
@@ -42,8 +42,9 @@ public class RefreshToken extends ValueObject implements Token {
         .build();
   }
 
-  public com.zerozero.core.domain.entity.RefreshToken toEntity() {
+  public com.zerozero.core.domain.entity.RefreshToken toEntity(UUID userId) {
     return com.zerozero.core.domain.entity.RefreshToken.builder()
+        .userId(userId)
         .refreshToken(this.getToken())
         .build();
   }


### PR DESCRIPTION
## AS-IS
- 리프레시 토큰을 MySQL에 관리

## TO-BE
- 리프레시 토큰을 Redis에서 관리

## 사용 이유
- Redis는 Key-Value 형태의 NoSQL이며, 적은 메모리로 저장 가능
- O(1) 시간 복잡도로 빠른 조회 가능
- In-Memory DB라 빠른 접근 가능
- TTL 설정 가능

## 배포 Docker YML
```yml

  redis:
    container_name: zerozero_redis
    image: redis:6.0.9
    ports:
      - '6379:6379'
    volumes: 
      - redis_data:/data
    networks:
      - zerozero_network
    restart: always

networks:
  zerozero_network:
    driver: bridge

volumes:
  redis_data:
```

## 고려 지점
- Redis Template와 Redis Repository가 있는데 Redis Repository을 이용함.
  - Redis Template를 사용해 Configuration까지 설정할 필요를 못느낌.
  - 추후 캐싱 처리 기능 구현 시 도입 시 변경 가능성 존재