### PR TITLE
FEAT: (#132) Presigned URL로 S3에 이미지를 업로드한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'commons-io:commons-io:2.16.1'
 }
 
 jar {

--- a/src/main/java/com/zerozero/core/util/AWSS3Service.java
+++ b/src/main/java/com/zerozero/core/util/AWSS3Service.java
@@ -60,46 +60,34 @@ public class AWSS3Service {
     }
   }
 
-  public String uploadImage(MultipartFile multipartFile) throws IOException {
-    String fileName = createFileName(multipartFile.getOriginalFilename());
+  public String uploadImage(String prefix, MultipartFile multipartFile) throws IOException {
+    String fileName = createFilePath(prefix, multipartFile.getOriginalFilename());
 
-    String fileExtension = getFileExtension(fileName);
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(multipartFile.getSize());
+    objectMetadata.setContentType(multipartFile.getContentType());
 
-    if (isValidImageFileExtension(fileExtension)) {
-
-      ObjectMetadata objectMetadata = new ObjectMetadata();
-      objectMetadata.setContentLength(multipartFile.getSize());
-      objectMetadata.setContentType(multipartFile.getContentType());
-
-      amazonS3.putObject(bucket, fileName, multipartFile.getInputStream(), objectMetadata);
-      return getUrl(bucket, fileName);
-    } else {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원되지 않는 이미지 형식입니다.");
-    }
+    amazonS3.putObject(bucket, fileName, multipartFile.getInputStream(), objectMetadata);
+    return getUrl(bucket, fileName);
   }
 
-  public List<String> uploadImages(List<MultipartFile> multipartFiles) {
+  public List<String> uploadImages(String prefix, List<MultipartFile> multipartFiles) {
     List<String> imageUrls = new ArrayList<>();
 
     multipartFiles.forEach(file -> {
-          String fileName = createFileName(file.getOriginalFilename());
-          String fileExtension = getFileExtension(fileName);
+      String fileName = createFilePath(prefix, file.getOriginalFilename());
 
-      if (isValidImageFileExtension(fileExtension)) {
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(file.getSize());
-        objectMetadata.setContentType(file.getContentType());
+      ObjectMetadata objectMetadata = new ObjectMetadata();
+      objectMetadata.setContentLength(file.getSize());
+      objectMetadata.setContentType(file.getContentType());
 
-        try (InputStream inputStream = file.getInputStream()) {
-          amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
-              .withCannedAcl(CannedAccessControlList.PublicRead));
-        } catch (IOException e) {
-          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
-        }
-        imageUrls.add(getUrl(bucket, fileName));
-      } else {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원되지 않는 이미지 형식입니다.");
+      try (InputStream inputStream = file.getInputStream()) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+            .withCannedAcl(CannedAccessControlList.PublicRead));
+      } catch (IOException e) {
+        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
       }
+      imageUrls.add(getUrl(bucket, fileName));
     });
     return imageUrls;
   }
@@ -131,21 +119,8 @@ public class AWSS3Service {
     return String.format("%s/%s-%s", prefix, fileUuid, fileName);
   }
 
-  private String getFileExtension(String fileName){
-    try{
-      return fileName.substring(fileName.lastIndexOf("."));
-    } catch (StringIndexOutOfBoundsException e){
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일" + fileName + ") 입니다.");
-    }
-  }
-
   private String getUrl(String bucket, String fileName) {
     return amazonS3.getUrl(bucket, fileName).toString();
-  }
-
-  private boolean isValidImageFileExtension(String fileExtension) {
-    return fileExtension.equalsIgnoreCase(".png") || fileExtension.equalsIgnoreCase(".jpeg")
-        || fileExtension.equalsIgnoreCase(".jpg");
   }
 
   @Getter

--- a/src/main/java/com/zerozero/core/util/AWSS3Service.java
+++ b/src/main/java/com/zerozero/core/util/AWSS3Service.java
@@ -1,14 +1,23 @@
 package com.zerozero.core.util;
 
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -24,6 +33,32 @@ public class AWSS3Service {
   private String bucket;
 
   private final AmazonS3 amazonS3;
+
+  public String getPreSignedUrl(String prefix, String fileName) {
+    if (prefix == null || prefix.isEmpty()) {
+      return null;
+    }
+    String filePath = createFilePath(prefix, fileName);
+    GeneratePresignedUrlRequest generatePresignedUrlRequest = createGeneratePresignedUrlRequest(bucket, filePath);
+    try {
+      URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+      return url.toString();
+    } catch (SdkClientException e) {
+      return null;
+    }
+  }
+
+  public String getObjectUrlFromPreSignedUrl(String preSignedUrl) {
+    if (preSignedUrl == null || preSignedUrl.isEmpty()) {
+      return null;
+    }
+    try {
+      URL url = new URL(preSignedUrl);
+      return String.format("%s://%s%s", url.getProtocol(), url.getHost(), url.getPath());
+    } catch (MalformedURLException e) {
+      return null;
+    }
+  }
 
   public String uploadImage(MultipartFile multipartFile) throws IOException {
     String fileName = createFileName(multipartFile.getOriginalFilename());
@@ -69,8 +104,31 @@ public class AWSS3Service {
     return imageUrls;
   }
 
-  private String createFileName(String fileName){
-    return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+  private GeneratePresignedUrlRequest createGeneratePresignedUrlRequest(String bucket, String filePath) {
+    GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, filePath)
+        .withMethod(HttpMethod.PUT)
+        .withExpiration(getPreSignedUrlExpiration());
+    generatePresignedUrlRequest.addRequestParameter(
+        Headers.S3_CANNED_ACL,
+        CannedAccessControlList.PublicRead.toString());
+    return generatePresignedUrlRequest;
+  }
+
+  private Date getPreSignedUrlExpiration() {
+    Date expiration = new Date();
+    long expTimeMillis = expiration.getTime();
+    expTimeMillis += 1000 * 60;
+    expiration.setTime(expTimeMillis);
+    return expiration;
+  }
+
+  private String createFileUuid() {
+    return UUID.randomUUID().toString();
+  }
+
+  private String createFilePath(String prefix, String fileName) {
+    String fileUuid = createFileUuid();
+    return String.format("%s/%s-%s", prefix, fileUuid, fileName);
   }
 
   private String getFileExtension(String fileName){
@@ -88,5 +146,22 @@ public class AWSS3Service {
   private boolean isValidImageFileExtension(String fileExtension) {
     return fileExtension.equalsIgnoreCase(".png") || fileExtension.equalsIgnoreCase(".jpeg")
         || fileExtension.equalsIgnoreCase(".jpg");
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum Prefix {
+    STORE("store"),
+    USER("user"),
+    ;
+
+    private final String prefix;
+
+    public static Prefix fromString(String value) {
+      return Arrays.stream(Prefix.values())
+          .filter(prefix -> prefix.getPrefix().equalsIgnoreCase(value))
+          .findFirst()
+          .orElse(null);
+    }
   }
 }

--- a/src/main/java/com/zerozero/image/application/ReadPreSignedUrlUseCase.java
+++ b/src/main/java/com/zerozero/image/application/ReadPreSignedUrlUseCase.java
@@ -1,0 +1,118 @@
+package com.zerozero.image.application;
+
+import com.zerozero.core.application.BaseRequest;
+import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.application.BaseUseCase;
+import com.zerozero.core.exception.DomainException;
+import com.zerozero.core.exception.error.BaseErrorCode;
+import com.zerozero.core.util.AWSS3Service;
+import com.zerozero.core.util.AWSS3Service.Prefix;
+import com.zerozero.image.application.ReadPreSignedUrlUseCase.ReadPreSignedUrlRequest;
+import com.zerozero.image.application.ReadPreSignedUrlUseCase.ReadPreSignedUrlResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ReadPreSignedUrlUseCase implements BaseUseCase<ReadPreSignedUrlRequest, ReadPreSignedUrlResponse> {
+
+  private final AWSS3Service awss3Service;
+
+  @Override
+  public ReadPreSignedUrlResponse execute(ReadPreSignedUrlRequest request) {
+    if (request == null || !request.isValid()) {
+      log.error("[ReadPreSignedUrlResponse] Invalid request");
+      return ReadPreSignedUrlResponse.builder()
+          .success(false)
+          .errorCode(ReadPreSignedUrlErrorCode.NOT_EXIST_REQUEST_CONDITION)
+          .build();
+    }
+    Prefix prefix = Prefix.fromString(request.getPrefix());
+    if (prefix == null) {
+      log.error("[ReadPreSignedUrlResponse] Invalid prefix: {}", request.getPrefix());
+      return ReadPreSignedUrlResponse.builder()
+          .success(false)
+          .errorCode(ReadPreSignedUrlErrorCode.INVALID_PREFIX)
+          .build();
+    }
+    String preSignedUrl = awss3Service.getPreSignedUrl(prefix.getPrefix(), request.getFileName());
+    String objectUrl = awss3Service.getObjectUrlFromPreSignedUrl(preSignedUrl);
+    if (preSignedUrl == null || objectUrl == null) {
+      log.error("[ReadPreSignedUrlResponse] Generated URLs(PreSigned, Object) are null");
+      return ReadPreSignedUrlResponse.builder()
+          .success(false)
+          .errorCode(ReadPreSignedUrlErrorCode.FAILED_TO_MAKE_URL)
+          .build();
+    }
+    log.info("[ReadPreSignedUrlResponse] Generated URLs - PreSigned: {}, Object: {}", preSignedUrl, objectUrl);
+    return ReadPreSignedUrlResponse.builder()
+        .preSignedUrl(preSignedUrl)
+        .objectUrl(objectUrl)
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ReadPreSignedUrlErrorCode implements BaseErrorCode<DomainException> {
+    NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 올바르지 않습니다."),
+    INVALID_PREFIX(HttpStatus.BAD_REQUEST, "유효하지 않은 prefix 값입니다."),
+    FAILED_TO_MAKE_URL(HttpStatus.INTERNAL_SERVER_ERROR, "PreSigned URL 생성에 실패했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class ReadPreSignedUrlResponse extends BaseResponse<ReadPreSignedUrlErrorCode> {
+
+    private String preSignedUrl;
+
+    private String objectUrl;
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class ReadPreSignedUrlRequest implements BaseRequest {
+
+    private String prefix;
+
+    private String fileName;
+
+    @Override
+    public boolean isValid() {
+      if (prefix == null || prefix.isEmpty() || fileName == null || fileName.isEmpty()) {
+        return false;
+      }
+      String extension = FilenameUtils.getExtension(fileName).toUpperCase();
+      return extension.equals("PNG") || extension.equals("JPG") || extension.equals("JPEG") || extension.equals("HEIC");
+    }
+  }
+}

--- a/src/main/java/com/zerozero/image/presentation/ReadPreSignedUrlController.java
+++ b/src/main/java/com/zerozero/image/presentation/ReadPreSignedUrlController.java
@@ -1,0 +1,97 @@
+package com.zerozero.image.presentation;
+
+import com.zerozero.configuration.interceptor.Authorization;
+import com.zerozero.configuration.swagger.ApiErrorCode;
+import com.zerozero.core.application.BaseRequest;
+import com.zerozero.core.application.BaseResponse;
+import com.zerozero.core.exception.error.GlobalErrorCode;
+import com.zerozero.image.application.ReadPreSignedUrlUseCase;
+import com.zerozero.image.application.ReadPreSignedUrlUseCase.ReadPreSignedUrlErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Image", description = "이미지")
+public class ReadPreSignedUrlController {
+
+  private final ReadPreSignedUrlUseCase readPreSignedUrlUseCase;
+
+  @Operation(
+      summary = "이미지 업로드 PreSigned URL 조회 API",
+      description = "클라이언트에서 AWS S3 버킷에 이미지를 저장하기 위한 PreSigned URL을 조회합니다.",
+      operationId = "/image/presigned-url"
+  )
+  @ApiErrorCode({GlobalErrorCode.class, ReadPreSignedUrlErrorCode.class})
+  @Authorization
+  @GetMapping("/image/presigned-url")
+  public ResponseEntity<ReadPreSignedUrlResponse> readPreSignedUrl(@ParameterObject ReadPreSignedUrlRequest request) {
+    ReadPreSignedUrlUseCase.ReadPreSignedUrlResponse readPreSignedUrlResponse = readPreSignedUrlUseCase.execute(
+        ReadPreSignedUrlUseCase.ReadPreSignedUrlRequest.builder()
+            .prefix(request.getPrefix())
+            .fileName(request.getFileName())
+            .build());
+    if (readPreSignedUrlResponse == null || !readPreSignedUrlResponse.isSuccess()) {
+      Optional.ofNullable(readPreSignedUrlResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+    return ResponseEntity.ok(
+        ReadPreSignedUrlResponse.builder()
+            .preSignedUrl(readPreSignedUrlResponse.getPreSignedUrl())
+            .objectUrl(readPreSignedUrlResponse.getObjectUrl())
+            .build());
+  }
+
+  @ToString
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  @Schema(description = "이미지 업로드 PreSigned URL 조회 응답")
+  public static class ReadPreSignedUrlResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "이미지 업로드 PreSigned URL", example = "https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/0cbf3b99-b0ba-4148-a891-d04cb71ae236-test.png")
+    private String preSignedUrl;
+
+    @Schema(description = "이미지 객체 URL", example = "https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/0cbf3b99-b0ba-4148-a891-d04cb71ae236-test.png")
+    private String objectUrl;
+  }
+
+
+  @ToString
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  @Schema(description = "이미지 업로드 PreSigned URL 조회 요청")
+  public static class ReadPreSignedUrlRequest implements BaseRequest {
+
+    @Schema(description = "이미지 접두사 ['store', 'user']", example = "store")
+    private String prefix;
+
+    @Schema(description = "업로드된 이미지 파일명", example = "profile-image.png")
+    private String fileName;
+  }
+}

--- a/src/main/java/com/zerozero/store/application/CreateStoreUseCase.java
+++ b/src/main/java/com/zerozero/store/application/CreateStoreUseCase.java
@@ -8,33 +8,34 @@ import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.domain.infra.repository.StoreJPARepository;
 import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
-import com.zerozero.core.util.AWSS3Service;
 import com.zerozero.external.kakao.search.application.RequestKakaoKeywordSearchUseCase;
 import com.zerozero.external.kakao.search.application.RequestKakaoKeywordSearchUseCase.RequestKakaoKeywordSearchRequest;
 import com.zerozero.external.kakao.search.dto.KeywordSearchResponse;
 import com.zerozero.external.kakao.search.dto.KeywordSearchResponse.Document;
 import com.zerozero.store.application.CreateStoreUseCase.CreateStoreRequest;
 import com.zerozero.store.application.CreateStoreUseCase.CreateStoreResponse;
-import io.jsonwebtoken.io.IOException;
-import lombok.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class CreateStoreUseCase implements BaseUseCase<CreateStoreRequest, CreateStoreResponse> {
-
-  private final AWSS3Service awss3Service;
 
   private final RequestKakaoKeywordSearchUseCase requestKakaoKeywordSearchUseCase;
 
@@ -73,23 +74,7 @@ public class CreateStoreUseCase implements BaseUseCase<CreateStoreRequest, Creat
           .errorCode(CreateStoreErrorCode.NOT_EXIST_STORE)
           .build();
     }
-    List<String> imageUrls;
-    try {
-      imageUrls = awss3Service.uploadImages(request.getImageFiles());
-      if (imageUrls == null || imageUrls.isEmpty()) {
-        log.error("[CreateStoreUseCase] Failed to upload images");
-        return CreateStoreResponse.builder()
-            .success(false)
-            .errorCode(CreateStoreErrorCode.FAILED_IMAGE_CONVERT)
-            .build();
-      }
-    } catch (IOException e) {
-      return CreateStoreResponse.builder()
-          .success(false)
-          .errorCode(CreateStoreErrorCode.FAILED_IMAGE_CONVERT)
-          .build();
-    }
-    Store store = Store.of(user.getId(), matchedStore, imageUrls);
+    Store store = Store.of(user.getId(), matchedStore, request.getImages());
     if (store == null) {
       return CreateStoreResponse.builder()
           .success(false)
@@ -106,8 +91,8 @@ public class CreateStoreUseCase implements BaseUseCase<CreateStoreRequest, Creat
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "등록 요청 조건이 올바르지 않습니다."),
     NOT_EXIST_SEARCH_RESPONSE(HttpStatus.BAD_REQUEST, "검색 응답이 존재하지 않습니다."),
     NOT_EXIST_STORE(HttpStatus.BAD_REQUEST, "등록된 판매점이 존재하지 않습니다."),
-    FAILED_IMAGE_CONVERT(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환에 실패하였습니다."),
-    FAILED_CREATE_STORE(HttpStatus.INTERNAL_SERVER_ERROR, "판매점 등록에 실패하였습니다.");
+    FAILED_CREATE_STORE(HttpStatus.INTERNAL_SERVER_ERROR, "판매점 등록에 실패하였습니다."),
+    ;
 
     private final HttpStatus httpStatus;
 
@@ -143,14 +128,14 @@ public class CreateStoreUseCase implements BaseUseCase<CreateStoreRequest, Creat
 
     private String latitude;
 
-    private List<MultipartFile> imageFiles;
+    private List<String> images;
 
     private User user;
 
     @Override
     public boolean isValid() {
       return placeName != null && longitude != null && !longitude.isEmpty() && latitude != null
-          && !latitude.isEmpty() && imageFiles != null && !imageFiles.isEmpty()
+          && !latitude.isEmpty() && images != null && !images.isEmpty()
           && user != null;
     }
   }

--- a/src/main/java/com/zerozero/store/presentation/CreateStoreController.java
+++ b/src/main/java/com/zerozero/store/presentation/CreateStoreController.java
@@ -18,19 +18,24 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -48,16 +53,15 @@ public class CreateStoreController {
   )
   @ApiErrorCode({GlobalErrorCode.class, CreateStoreErrorCode.class})
   @Authorization
-  @PostMapping(value = "/store", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<CreateStoreResponse> createStore(@Valid @ParameterObject CreateStoreRequest request,
-                                                         @RequestPart @Parameter(description = "이미지 원본 파일") List<MultipartFile> imageFiles,
+  @PostMapping("/store")
+  public ResponseEntity<CreateStoreResponse> createStore(@Valid @RequestBody CreateStoreRequest request,
                                                          @Parameter(hidden = true) @LoginUser User user) {
     CreateStoreUseCase.CreateStoreResponse createStoreResponse = createStoreUseCase.execute(
         CreateStoreUseCase.CreateStoreRequest.builder()
             .placeName(request.getPlaceName())
             .longitude(request.getLongitude())
             .latitude(request.getLatitude())
-            .imageFiles(imageFiles)
+            .images(request.getImages())
             .user(user)
             .build());
     if (createStoreResponse == null || !createStoreResponse.isSuccess()) {
@@ -114,5 +118,10 @@ public class CreateStoreController {
     @NotNull(message = "판매점 y좌표(위도)는 필수 값입니다.")
     @Schema(description = "판매점 y좌표(위도)", example = "37.49206032952165")
     private String latitude;
+
+    @NotNull(message = "판매점 사진은 필수 값입니다.")
+    @Schema(description = "판매점 업로드 이미지 URL 리스트",
+        example = "[\"https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/0cbf3b99-b0ba-4148-a891-d04cb71ae236-test.png\", \"https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/another-image.png\"]")
+    private List<String> images;
   }
 }

--- a/src/main/java/com/zerozero/user/application/UpdateUserProfileUseCase.java
+++ b/src/main/java/com/zerozero/user/application/UpdateUserProfileUseCase.java
@@ -7,26 +7,27 @@ import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.domain.vo.Image;
 import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
-import com.zerozero.core.util.AWSS3Service;
 import com.zerozero.user.application.UpdateUserProfileUseCase.UpdateUserProfileRequest;
 import com.zerozero.user.application.UpdateUserProfileUseCase.UpdateUserProfileResponse;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class UpdateUserProfileUseCase implements BaseUseCase<UpdateUserProfileRequest, UpdateUserProfileResponse> {
-
-  private final AWSS3Service awss3Service;
 
   @Override
   public UpdateUserProfileResponse execute(UpdateUserProfileRequest request) {
@@ -37,24 +38,11 @@ public class UpdateUserProfileUseCase implements BaseUseCase<UpdateUserProfileRe
           .build();
     }
     User user = request.getUser();
-    MultipartFile imageFile = request.getImageFile();
-    if (imageFile == null) {
+    String image = request.getImage();
+    if (image == null) {
       user.uploadProfileImage(null);
     } else {
-      String imageUrl;
-      try {
-        imageUrl = awss3Service.uploadImage(imageFile);
-        if (imageUrl == null || imageUrl.isEmpty()) {
-          log.error("[UpdateUserProfileUseCase] imageUrl is null");
-          return UpdateUserProfileResponse.builder().success(false)
-              .errorCode(UpdateUserProfileErrorCode.FAILED_IMAGE_CONVERT).build();
-        }
-      } catch (IOException e) {
-        log.error("[UpdateUserProfileUseCase] image upload error", e);
-        return UpdateUserProfileResponse.builder().success(false)
-            .errorCode(UpdateUserProfileErrorCode.FAILED_IMAGE_CONVERT).build();
-      }
-      user.uploadProfileImage(Image.convertUrlToImage(imageUrl));
+      user.uploadProfileImage(Image.convertUrlToImage(image));
     }
     if (!request.getNickname().equals(user.getNickname())) {
       user.updateNickname(request.getNickname());
@@ -66,7 +54,7 @@ public class UpdateUserProfileUseCase implements BaseUseCase<UpdateUserProfileRe
   @RequiredArgsConstructor
   public enum UpdateUserProfileErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REQUEST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 올바르지 않습니다."),
-    FAILED_IMAGE_CONVERT(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환에 실패하였습니다.");
+    ;
 
     private final HttpStatus httpStatus;
 
@@ -96,7 +84,7 @@ public class UpdateUserProfileUseCase implements BaseUseCase<UpdateUserProfileRe
 
     private String nickname;
 
-    private MultipartFile imageFile;
+    private String image;
 
     private User user;
 

--- a/src/main/java/com/zerozero/user/presentation/UpdateUserProfileController.java
+++ b/src/main/java/com/zerozero/user/presentation/UpdateUserProfileController.java
@@ -13,18 +13,22 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,15 +44,14 @@ public class UpdateUserProfileController {
   )
   @ApiErrorCode({GlobalErrorCode.class, UpdateUserProfileErrorCode.class})
   @Authorization
-  @PatchMapping(value = "/user", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PatchMapping("/user")
   public ResponseEntity<UpdateUserProfileResponse> uploadProfileImage(
-          @ParameterObject UpdateUserProfileRequest userProfileRequest,
-          @RequestPart(required = false) @Parameter(description = "이미지 원본 파일") MultipartFile imageFile,
-          @Parameter(hidden = true) @LoginUser User user) {
+      @Valid @RequestBody UpdateUserProfileRequest request,
+      @Parameter(hidden = true) @LoginUser User user) {
     UpdateUserProfileUseCase.UpdateUserProfileResponse updateUserProfileResponse = updateUserProfileUseCase.execute(
         UpdateUserProfileUseCase.UpdateUserProfileRequest.builder()
-            .nickname(userProfileRequest.getNickname())
-            .imageFile(imageFile)
+            .nickname(request.getNickname())
+            .image(request.getImage())
             .user(user)
             .build());
     if (updateUserProfileResponse == null || !updateUserProfileResponse.isSuccess()) {
@@ -84,5 +87,8 @@ public class UpdateUserProfileController {
     @NotNull(message = "닉네임은 필수 데이터입니다.")
     @Schema(description = "닉네임", example = "제로")
     private String nickname;
+
+    @Schema(description = "판매점 업로드 이미지 URL", example = "https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/0cbf3b99-b0ba-4148-a891-d04cb71ae236-test.png")
+    private String image;
   }
 }


### PR DESCRIPTION
## AS-IS
- MultiPartFile을 받아 서버에서 S3로 업로드한다.
  - 서버 부하 (파일 크기 문제)
  - 서버 리소스 문제 (CPU, Memory 자원 소비)
  - 네트워크 대역폭 문제 (클라이언트 - 서버 - S3)
 
## TO-BE
- Presigned URL를 프론트에 제공한 뒤, 프론트에서 직접 S3에 업로드한다.
  - 서버 부하 감소
  - 네트워크 효율성
 
## Extra
- Presigned URL의 유효 시간은 1분으로 설정
  - 사진만 업로드할 수 있기 때문에 짧게 설정
- Prefix를 요청으로 받아서 Enum으로 관리
  - 객체 스토리지의 상위 디렉토리를 관리하기 위함
- Presigned URL 반환 시, 객체 URL도 같이 반환
  - 업로드 이후, 저장 API를 호출할 때, DB에 저장해야하기 때문이다.


