### PR TITLE
FIX: (#134) 회원가입 시 @LoginUser 대신 Authorization 헤더의 토큰을 직접 검증하도록 변경한다

### DIFF
--- a/src/main/java/com/zerozero/auth/application/RegisterUserUseCase.java
+++ b/src/main/java/com/zerozero/auth/application/RegisterUserUseCase.java
@@ -5,9 +5,13 @@ import com.zerozero.auth.application.RegisterUserUseCase.RegisterUserResponse;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
 import com.zerozero.core.application.BaseUseCase;
+import com.zerozero.core.domain.entity.Status;
 import com.zerozero.core.domain.entity.User;
+import com.zerozero.core.domain.infra.repository.UserJPARepository;
 import com.zerozero.core.exception.DomainException;
 import com.zerozero.core.exception.error.BaseErrorCode;
+import com.zerozero.core.util.JwtUtil;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,14 +32,35 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RegisterUserUseCase implements BaseUseCase<RegisterUserRequest, RegisterUserResponse> {
 
+  private final JwtUtil jwtUtil;
+
+  private final UserJPARepository userJPARepository;
+
   @Override
   public RegisterUserResponse execute(RegisterUserRequest request) {
     if (request == null || !request.isValid()) {
       log.error("[RegisterUserUseCase] Invalid register request");
-      return RegisterUserResponse.builder().success(false)
-          .errorCode(RegisterUserErrorCode.NOT_EXIST_REGISTER_CONDITION).build();
+      return RegisterUserResponse.builder()
+          .success(false)
+          .errorCode(RegisterUserErrorCode.NOT_EXIST_REGISTER_CONDITION)
+          .build();
     }
-    User user = request.user;
+    UUID userId = jwtUtil.extractUserId(request.getAccessToken());
+    User user = userJPARepository.findById(userId).orElse(null);
+    if (user == null) {
+      log.error("[RegisterUserUseCase] User with id {} not found", userId);
+      return RegisterUserResponse.builder()
+              .success(false)
+              .errorCode(RegisterUserErrorCode.NOT_EXIST_USER)
+              .build();
+    }
+    if (user.getStatus() == Status.COMPLETED) {
+      log.error("[RegisterUserUseCase] User with id {} is already registered", userId);
+      return RegisterUserResponse.builder()
+              .success(false)
+              .errorCode(RegisterUserErrorCode.ALREADY_REGISTERED_USER)
+              .build();
+    }
     user.completePendingUser(request.getNickname());
     return RegisterUserResponse.builder()
         .user(com.zerozero.core.domain.vo.User.of(user))
@@ -47,6 +72,7 @@ public class RegisterUserUseCase implements BaseUseCase<RegisterUserRequest, Reg
   public enum RegisterUserErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_REGISTER_CONDITION(HttpStatus.BAD_REQUEST, "회원가입 조건이 올바르지 않습니다."),
     NOT_EXIST_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
+    ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 회원가입이 완료된 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;
@@ -75,13 +101,13 @@ public class RegisterUserUseCase implements BaseUseCase<RegisterUserRequest, Reg
   @NoArgsConstructor(access = AccessLevel.PROTECTED)
   @AllArgsConstructor(access = AccessLevel.PROTECTED)
   public static class RegisterUserRequest implements BaseRequest {
-    private User user;
+    private String accessToken;
 
     private String nickname;
 
     @Override
     public boolean isValid() {
-      return user != null && nickname != null && !nickname.isEmpty();
+      return accessToken != null && !accessToken.isEmpty() && nickname != null && !nickname.isEmpty();
     }
   }
 

--- a/src/main/java/com/zerozero/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/com/zerozero/auth/exception/AuthenticationErrorCode.java
@@ -22,6 +22,7 @@ public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
   ACCESS_TOKEN_NOT_ISSUED(HttpStatus.BAD_GATEWAY, "OAuth 써드파티 제공자에서 액세스 토큰이 발급되지 않았습니다."),
   NOT_EXIST_RESOURCE_RESPONSE(HttpStatus.BAD_GATEWAY, "OAuth 써드파티 리소스 서버에서 자원이 존재하지 않습니다."),
   RESOURCE_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Server에 접근할 수 없습니다."),
+  NOT_COMPLETED_MEMBER(HttpStatus.FORBIDDEN, "회원가입이 완료되지 않은 사용자입니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/zerozero/auth/presentation/RegisterUserController.java
+++ b/src/main/java/com/zerozero/auth/presentation/RegisterUserController.java
@@ -2,12 +2,10 @@ package com.zerozero.auth.presentation;
 
 import com.zerozero.auth.application.RegisterUserUseCase;
 import com.zerozero.auth.application.RegisterUserUseCase.RegisterUserErrorCode;
-import com.zerozero.configuration.argumentresolver.LoginUser;
 import com.zerozero.configuration.interceptor.Authorization;
 import com.zerozero.configuration.swagger.ApiErrorCode;
 import com.zerozero.core.application.BaseRequest;
 import com.zerozero.core.application.BaseResponse;
-import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.exception.error.GlobalErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,20 +13,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,14 +38,13 @@ public class RegisterUserController {
   @ApiErrorCode({GlobalErrorCode.class, RegisterUserErrorCode.class})
   @Authorization
   @PostMapping("/register")
-  public ResponseEntity<RegisterUserResponse> registerUser(
-      @Valid @RequestBody RegisterUserRequest registerUserRequest,
-      @Parameter(hidden = true) @LoginUser User user) {
+  public ResponseEntity<RegisterUserResponse> registerUser(@Valid @RequestBody RegisterUserRequest registerUserRequest,
+                                                           @Parameter(hidden = true) @RequestHeader("Authorization") String authorizationHeader) {
     RegisterUserUseCase.RegisterUserResponse registerUserResponse = registerUserUseCase.execute(
-        RegisterUserUseCase.RegisterUserRequest.builder()
-            .user(user)
-            .nickname(registerUserRequest.getNickname())
-            .build());
+            RegisterUserUseCase.RegisterUserRequest.builder()
+                    .accessToken(authorizationHeader.substring(7))
+                    .nickname(registerUserRequest.getNickname())
+                    .build());
     if (registerUserResponse == null || !registerUserResponse.isSuccess()) {
       Optional.ofNullable(registerUserResponse)
           .map(BaseResponse::getErrorCode)

--- a/src/main/java/com/zerozero/configuration/argumentresolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/zerozero/configuration/argumentresolver/LoginUserArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.zerozero.configuration.argumentresolver;
 
 import com.zerozero.auth.exception.AuthenticationErrorCode;
+import com.zerozero.core.domain.entity.Status;
+import com.zerozero.core.domain.entity.User;
 import com.zerozero.core.domain.infra.repository.UserJPARepository;
 import com.zerozero.core.util.JwtUtil;
 import java.util.UUID;
@@ -34,7 +36,12 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         String authorizationHeader = webRequest.getHeader(AUTHORIZATION_HEADER);
         String token = extractToken(authorizationHeader);
         UUID userId = jwtUtil.extractUserId(token);
-        return userJPARepository.findById(userId).orElseThrow(AuthenticationErrorCode.NOT_FOUND_MEMBER::toException);
+        User user = userJPARepository.findById(userId)
+                .orElseThrow(AuthenticationErrorCode.NOT_FOUND_MEMBER::toException);
+        if (user.getStatus() != Status.COMPLETED) {
+            throw AuthenticationErrorCode.NOT_COMPLETED_MEMBER.toException();
+        }
+        return user;
     }
 
     private String extractToken(String authorizationHeader) {


### PR DESCRIPTION
## AS-IS
- `@LoginUser` 를 이용해 User 객체를 토큰에서 가져온다.
- 이때 발생하는 문제가 User의 가입 상태에 따라 인가 권한이 주어지는 것이 아닌, 도중 이탈한 User에게도 인가 권한이 주어진다.

## TO-BE
- `@LoginUser` 에 가입 상태를 비교하여 가입이 완료된 사용자만 가져올 수 있게 변경한다.
- 가입이 완료되지 않은 사용자의 기능(ex. 회원가입)에서는 Authorization Header에서 직접 토큰을 가져와 검증하도록 변경한다.