### PR TITLE
REFACTOR: (#137) Gradle 설정을 역할별로 분리한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,59 +16,14 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
-    implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
-    runtimeOnly 'com.mysql:mysql-connector-j'
-
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-
-    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
-    implementation 'javax.xml.bind:jaxb-api:2.3.1'
-    implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
-
-    implementation 'org.springframework.boot:spring-boot-starter-batch'
-    testImplementation 'org.springframework.batch:spring-batch-test'
-
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
-
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
-    implementation 'commons-io:commons-io:2.16.1'
-}
-
-jar {
-    enabled = false
-}
-
 tasks.named('test') {
     useJUnitPlatform()
 }
 
-def generated = 'src/main/generated'
-tasks.withType(JavaCompile).configureEach {
-    options.getGeneratedSourceOutputDirectory().set(file(generated))
-}
-clean {
-    delete file('src/main/generated')
-}
+apply from: "gradle/cloud.gradle"
+apply from: "gradle/db.gradle"
+apply from: "gradle/docs.gradle"
+apply from: "gradle/jwt.gradle"
+apply from: "gradle/spring.gradle"
+apply from: "gradle/test.gradle"
+apply from: "gradle/util.gradle"

--- a/gradle/cloud.gradle
+++ b/gradle/cloud.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+}

--- a/gradle/db.gradle
+++ b/gradle/db.gradle
@@ -1,0 +1,16 @@
+dependencies {
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    def generated = 'src/main/generated'
+    tasks.withType(JavaCompile).configureEach {
+        options.getGeneratedSourceOutputDirectory().set(file(generated))
+    }
+    clean {
+        delete file('src/main/generated')
+    }
+}

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+}

--- a/gradle/jwt.gradle
+++ b/gradle/jwt.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+}

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -1,0 +1,17 @@
+jar {
+    enabled = false
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+}

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,0 +1,8 @@
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+dependencies {
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+}

--- a/gradle/util.gradle
+++ b/gradle/util.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'commons-io:commons-io:2.16.1'
+    implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+}


### PR DESCRIPTION
## AS-IS
- 모든 설정을 하나의 gradle파일에 두어 build.gradle이 뚱뚱해지는 문제 발생
- 추후 dependency가 늘어날 경우, 관리하기 힘들어지는 문제 발생

## TO-BE
- 각 dependency의 역할별로 gradle을 분리하여 관리하기 용이하게 변경