### PR TITLE
FEAT: (#150) 판매점 등록 시 RabbitMQ 메시지 전송을 트랜잭션 커밋 이후로 변경한다

### DIFF
--- a/src/main/java/com/zerozero/core/infrastructure/rabbitmq/MessageProducer.java
+++ b/src/main/java/com/zerozero/core/infrastructure/rabbitmq/MessageProducer.java
@@ -1,6 +1,5 @@
 package com.zerozero.core.infrastructure.rabbitmq;
 
-import com.zerozero.configuration.ApplicationContextProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -9,13 +8,11 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 @RequiredArgsConstructor
 public abstract class MessageProducer<T extends BaseQueueProperty, R> {
 
-    private static final RabbitTemplate rabbitTemplate = ApplicationContextProvider.getBean("rabbitTemplate", RabbitTemplate.class);
+    private final RabbitTemplate rabbitTemplate;
 
     protected final T queueProperty;
 
-    protected final R request;
-
-    public void publishMessage() {
+    public void publishMessage(R request) {
         try {
             rabbitTemplate.convertAndSend(queueProperty.getExchange(), queueProperty.getRoutingKey(), request);
         } catch (Exception e) {
@@ -23,4 +20,3 @@ public abstract class MessageProducer<T extends BaseQueueProperty, R> {
         }
     }
 }
-

--- a/src/main/java/com/zerozero/store/domain/event/CreateStoreEvent.java
+++ b/src/main/java/com/zerozero/store/domain/event/CreateStoreEvent.java
@@ -1,0 +1,8 @@
+package com.zerozero.store.domain.event;
+
+import java.util.UUID;
+
+public record CreateStoreEvent(
+        UUID storeId
+) {
+}

--- a/src/main/java/com/zerozero/store/domain/service/CreateStoreUseCase.java
+++ b/src/main/java/com/zerozero/store/domain/service/CreateStoreUseCase.java
@@ -1,15 +1,15 @@
 package com.zerozero.store.domain.service;
 
+import com.zerozero.store.domain.event.CreateStoreEvent;
 import com.zerozero.store.domain.model.Store;
 import com.zerozero.store.domain.repository.StoreRepository;
 import com.zerozero.store.domain.response.StoreSearchResponse;
 import com.zerozero.store.exception.StoreErrorType;
 import com.zerozero.store.exception.StoreException;
-import com.zerozero.store.infrastructure.rabbitmq.CreateStoreMessageProducer;
-import com.zerozero.store.infrastructure.rabbitmq.CreateStoreQueueProperty;
 import com.zerozero.store.presentation.request.CreateStoreRequest;
 import com.zerozero.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +25,7 @@ public class CreateStoreUseCase {
 
     private final StoreSearcher storeSearcher;
 
-    private final CreateStoreQueueProperty createStoreQueueProperty;
+    private final ApplicationEventPublisher eventPublisher;
 
     public UUID execute(CreateStoreRequest createStoreRequest, User user) {
         List<StoreSearchResponse> storeSearchResponses = storeSearcher.search(createStoreRequest.placeName());
@@ -42,9 +42,7 @@ public class CreateStoreUseCase {
         storeRepository.save(store);
 
         UUID storeId = store.getId();
-        CreateStoreMessageProducer createStoreMessageProducer = new CreateStoreMessageProducer(createStoreQueueProperty, storeId);
-        createStoreMessageProducer.publishMessage();
-
+        eventPublisher.publishEvent(new CreateStoreEvent(storeId));
         return storeId;
     }
 

--- a/src/main/java/com/zerozero/store/infrastructure/CreateStoreEventListener.java
+++ b/src/main/java/com/zerozero/store/infrastructure/CreateStoreEventListener.java
@@ -1,0 +1,29 @@
+package com.zerozero.store.infrastructure;
+
+import com.zerozero.store.domain.event.CreateStoreEvent;
+import com.zerozero.store.infrastructure.rabbitmq.CreateStoreMessageProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CreateStoreEventListener {
+
+    private final CreateStoreMessageProducer createStoreMessageProducer;
+
+    @TransactionalEventListener(
+            value = CreateStoreEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT
+    )
+    public void handleCreateStoreEvent(CreateStoreEvent createStoreEvent) {
+        try {
+            createStoreMessageProducer.publishMessage(createStoreEvent.storeId());
+        } catch (Exception e) {
+            log.error("[CreateStoreEventListener] Failed to publish CreateStoreEvent to RabbitMQ", e);
+        }
+    }
+}

--- a/src/main/java/com/zerozero/store/infrastructure/rabbitmq/CreateStoreMessageProducer.java
+++ b/src/main/java/com/zerozero/store/infrastructure/rabbitmq/CreateStoreMessageProducer.java
@@ -1,16 +1,15 @@
 package com.zerozero.store.infrastructure.rabbitmq;
 
 import com.zerozero.core.infrastructure.rabbitmq.MessageProducer;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
+@Component
 public class CreateStoreMessageProducer extends MessageProducer<CreateStoreQueueProperty, UUID> {
 
-    private CreateStoreMessageProducer() {
-        super(null, null);
-    }
-
-    public CreateStoreMessageProducer(CreateStoreQueueProperty queueProperty, UUID storeId) {
-        super(queueProperty, storeId);
+    public CreateStoreMessageProducer(RabbitTemplate rabbitTemplate, CreateStoreQueueProperty queueProperty) {
+        super(rabbitTemplate, queueProperty);
     }
 }


### PR DESCRIPTION
## AS-IS
#### 판매점 등록 트랜잭션과 별개로 RabbitMQ에 메시지가 발행된다.
- 판매점이 MySQL에 등록되지 않더라도 MongoDB에 저장되는 문제 발생. 

#### RabbitMQ Producer가 DI되지 않고, 로직 내에 숨겨져 있음.
- Mocking하여 테스트할 때 문제 발생.

## TO-BE
#### 도메인 이벤트와 `@TransactionalEventListener`를 사용하여 트랜잭션 커밋 후 메시지 발행하도록 변경.
#### RabbitMQ Producer를 빈으로 등록하여 DI하여 사용하도록 변경.