### PR TITLE
FIX: (#152) Image 엔티티를 밸류 타입으로 변경한다

### DIFF
--- a/src/main/java/com/zerozero/image/domain/model/Image.java
+++ b/src/main/java/com/zerozero/image/domain/model/Image.java
@@ -1,9 +1,8 @@
 package com.zerozero.image.domain.model;
 
-import com.zerozero.core.domain.BaseAutoIncrementEntity;
 import com.zerozero.image.exception.ImageErrorType;
 import com.zerozero.image.exception.ImageException;
-import jakarta.persistence.Entity;
+import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,15 +10,15 @@ import lombok.NoArgsConstructor;
 
 import java.util.Set;
 
-@Entity
+@Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Image extends BaseAutoIncrementEntity {
+public class Image {
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("PNG", "JPG", "JPEG", "HEIC");
 
-    private String url;
+    private String imageUrl;
 
     public static Image from(String image) {
         return new Image(image);

--- a/src/main/java/com/zerozero/store/domain/model/Store.java
+++ b/src/main/java/com/zerozero/store/domain/model/Store.java
@@ -40,7 +40,9 @@ public class Store extends BaseEntity {
     @Builder.Default
     private boolean status = false;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @ElementCollection
+    @CollectionTable(name = "store_images",
+            joinColumns = @JoinColumn(name = "storeId"))
     private List<Image> images = new ArrayList<>();
 
     private String placeUrl;

--- a/src/main/java/com/zerozero/store/domain/response/StoreResponse.java
+++ b/src/main/java/com/zerozero/store/domain/response/StoreResponse.java
@@ -59,7 +59,7 @@ public record StoreResponse(
                 .longitude(store.getGeoLocation().getLongitude())
                 .latitude(store.getGeoLocation().getLatitude())
                 .status(store.isStatus())
-                .images(store.getImages().stream().map(Image::getUrl).collect(Collectors.toList()))
+                .images(store.getImages().stream().map(Image::getImageUrl).collect(Collectors.toList()))
                 .placeUrl(store.getPlaceUrl())
                 .build();
     }

--- a/src/main/java/com/zerozero/user/application/UserService.java
+++ b/src/main/java/com/zerozero/user/application/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
         StoreUserRankResponse storeUserRankResponse = getStoreUserRankUseCase.execute(user.getId());
         return ReadUserInfoResponse.builder()
                 .nickname(user.getNickname())
-                .profileImage(Optional.ofNullable(user.getProfileImage()).map(Image::getUrl).orElse(null))
+                .profileImage(Optional.ofNullable(user.getProfileImage()).map(Image::getImageUrl).orElse(null))
                 .rank(storeUserRankResponse.rank())
                 .storeReportCount(storeUserRankResponse.storeReportCount())
                 .build();

--- a/src/main/java/com/zerozero/user/domain/model/User.java
+++ b/src/main/java/com/zerozero/user/domain/model/User.java
@@ -19,7 +19,7 @@ public class User extends BaseEntity {
 
     private String email;
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @Embedded
     private Image profileImage;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/zerozero/user/domain/response/UserResponse.java
+++ b/src/main/java/com/zerozero/user/domain/response/UserResponse.java
@@ -30,7 +30,7 @@ public record UserResponse(
                 user.getId(),
                 user.getNickname(),
                 user.getEmail(),
-                Optional.ofNullable(user.getProfileImage()).map(Image::getUrl).orElse(null),
+                Optional.ofNullable(user.getProfileImage()).map(Image::getImageUrl).orElse(null),
                 user.getUserStatus()
         );
     }


### PR DESCRIPTION
## AS-IS
- Image Entity 사용

## TO-BE
- ElementCollection 사용
  - 현재 서비스에서 판매점 등록과 사진 등록이 같이 수행됨.
  - ElementCollection과 OneToMany를 비교했을 때, 사진 수정/삭제 기능은 필요하지 않기 때문에 ElementCollection을 사용하는게 더 나을 것으로 판단.
- Fetch Join을 사용하여 Image를 한 번에 가져오도록 수정할 예정.