### PR TITLE
Fix: (#154) @SQLDelete, @SQLRestriction을 활용하여 Soft Delete를 개선한다

### DIFF
--- a/src/main/java/com/zerozero/core/domain/BaseAutoIncrementEntity.java
+++ b/src/main/java/com/zerozero/core/domain/BaseAutoIncrementEntity.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @MappedSuperclass
 @EntityListeners(value = AuditingEntityListener.class)
 @SuperBuilder

--- a/src/main/java/com/zerozero/core/domain/BaseEntity.java
+++ b/src/main/java/com/zerozero/core/domain/BaseEntity.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@Setter
 @MappedSuperclass
 @EntityListeners(value = AuditingEntityListener.class)
 @SuperBuilder

--- a/src/main/java/com/zerozero/review/application/ReviewService.java
+++ b/src/main/java/com/zerozero/review/application/ReviewService.java
@@ -38,7 +38,7 @@ public class ReviewService {
     }
 
     private boolean isUserAlreadyReviewed(UUID userId, UUID storeId) {
-        return reviewRepository.existsByUserIdAndStoreIdAndDeleted(userId, storeId, false);
+        return reviewRepository.existsByUserIdAndStoreId(userId, storeId);
     }
 
 }

--- a/src/main/java/com/zerozero/review/domain/model/Review.java
+++ b/src/main/java/com/zerozero/review/domain/model/Review.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.*;
 
@@ -13,6 +15,8 @@ import java.util.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @SuperBuilder
+@SQLDelete(sql = "UPDATE review SET deleted = true WHERE id = ?")
+@SQLRestriction("deleted = false")
 public class Review extends BaseEntity {
 
     @ElementCollection(fetch = FetchType.EAGER)
@@ -51,7 +55,4 @@ public class Review extends BaseEntity {
         this.zeroDrinks.addAll(zeroDrinks);
     }
 
-    public void deleted(boolean deleted) {
-        setDeleted(deleted);
-    }
 }

--- a/src/main/java/com/zerozero/review/domain/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/zerozero/review/domain/repository/ReviewLikeRepository.java
@@ -8,6 +8,6 @@ import java.util.UUID;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
-    Optional<ReviewLike> findByReviewIdAndUserIdAndDeleted(UUID reviewId, UUID userId, Boolean deleted);
+    Optional<ReviewLike> findByReviewIdAndUserId(UUID reviewId, UUID userId);
 
 }

--- a/src/main/java/com/zerozero/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/zerozero/review/domain/repository/ReviewRepository.java
@@ -3,13 +3,10 @@ package com.zerozero.review.domain.repository;
 import com.zerozero.review.domain.model.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
-    Boolean existsByUserIdAndStoreIdAndDeleted(UUID userId, UUID storeId, boolean deleted);
-
-    Optional<Review> findByIdAndDeleted(UUID id, Boolean deleted);
+    Boolean existsByUserIdAndStoreId(UUID userId, UUID storeId);
 
 }

--- a/src/main/java/com/zerozero/review/domain/service/DeleteStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/domain/service/DeleteStoreReviewUseCase.java
@@ -21,15 +21,13 @@ public class DeleteStoreReviewUseCase {
     private final ReviewRepository reviewRepository;
 
     public void execute(UUID reviewId, User user) {
-        Review review = reviewRepository.findByIdAndDeleted(reviewId, false)
+        Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorType.NOT_EXIST_DELETABLE_REVIEW));
         if (!review.isWrittenBy(user.getId())) {
             log.error("[DeleteStoreReviewUseCase] User does not have review with id {}", reviewId);
             throw new ReviewException(ReviewErrorType.USER_VALIDATION_FAILED);
         }
-        review.getReviewLikes().clear();
-        review.getZeroDrinks().clear();
-        review.deleted(true);
+        reviewRepository.delete(review);
     }
 
 }

--- a/src/main/java/com/zerozero/review/domain/service/LikeStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/domain/service/LikeStoreReviewUseCase.java
@@ -25,10 +25,10 @@ public class LikeStoreReviewUseCase {
     private final ReviewLikeRepository reviewLikeRepository;
 
     public void execute(UUID reviewId, User user) {
-        Review review = reviewRepository.findByIdAndDeleted(reviewId, false)
+        Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorType.NOT_EXIST_DELETABLE_REVIEW));
 
-        reviewLikeRepository.findByReviewIdAndUserIdAndDeleted(review.getId(), user.getId(), false)
+        reviewLikeRepository.findByReviewIdAndUserId(review.getId(), user.getId())
                 .ifPresentOrElse(
                         existingLike -> {
                             log.info("[Unlike] User {} unliked Review {}", user.getId(), review.getId());

--- a/src/main/java/com/zerozero/review/domain/service/ReadStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/domain/service/ReadStoreReviewUseCase.java
@@ -47,12 +47,11 @@ public class ReadStoreReviewUseCase {
     }
 
     private Map<UUID, User> getReviewAuthors(List<Review> reviews) {
-        return userRepository.findAllByIdInAndDeleted(
+        return userRepository.findAllByIdIn(
                 reviews.stream()
                         .map(Review::getUserId)
                         .distinct()
-                        .collect(Collectors.toList()),
-                false
+                        .collect(Collectors.toList())
         ).stream().collect(Collectors.toMap(User::getId, reviewAuthor -> reviewAuthor));
     }
 

--- a/src/main/java/com/zerozero/review/domain/service/UpdateStoreReviewUseCase.java
+++ b/src/main/java/com/zerozero/review/domain/service/UpdateStoreReviewUseCase.java
@@ -22,7 +22,7 @@ public class UpdateStoreReviewUseCase {
     private final ReviewRepository reviewRepository;
 
     public void execute(UUID reviewId, ReviewRequest reviewRequest, User user) {
-        Review review = reviewRepository.findByIdAndDeleted(reviewId, false).orElseThrow(() -> new ReviewException(ReviewErrorType.NOT_EXIST_REVIEW));
+        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new ReviewException(ReviewErrorType.NOT_EXIST_REVIEW));
         if (!review.isWrittenBy(user.getId())) {
             log.error("[UpdateStoreReviewUseCase] User does not have review with id {}", reviewId);
             throw new ReviewException(ReviewErrorType.USER_VALIDATION_FAILED);

--- a/src/main/java/com/zerozero/store/domain/model/Store.java
+++ b/src/main/java/com/zerozero/store/domain/model/Store.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +23,8 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @SuperBuilder
+@SQLDelete(sql = "UPDATE store SET deleted = true WHERE id = ?")
+@SQLRestriction("deleted = false")
 public class Store extends BaseEntity {
 
     private String kakaoId;

--- a/src/main/java/com/zerozero/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/zerozero/store/domain/repository/StoreRepository.java
@@ -19,7 +19,7 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
                 FROM (
                     SELECT u.id AS user_id,
                            RANK() OVER (ORDER BY COUNT(s.id) DESC) AS r
-                    FROM user u
+                    FROM users u
                     JOIN store s ON u.id = s.user_id
                     GROUP BY u.id
                 ) AS user_rank
@@ -29,5 +29,5 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
 
     Store findByNameAndGeoLocation(String name, GeoLocation geoLocation);
 
-    List<Store> findAllByUserIdAndDeleted(UUID userId, boolean deleted);
+    List<Store> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/zerozero/store/domain/service/ReadUserStoresUseCase.java
+++ b/src/main/java/com/zerozero/store/domain/service/ReadUserStoresUseCase.java
@@ -18,7 +18,7 @@ public class ReadUserStoresUseCase {
     private final StoreRepository storeRepository;
 
     public List<StoreResponse> execute(User user) {
-        return storeRepository.findAllByUserIdAndDeleted(user.getId(), false)
+        return storeRepository.findAllByUserId(user.getId())
                 .stream()
                 .map(StoreResponse::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/zerozero/user/domain/model/User.java
+++ b/src/main/java/com/zerozero/user/domain/model/User.java
@@ -7,12 +7,16 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Table(name = "users")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @SuperBuilder
+@SQLDelete(sql = "UPDATE users SET deleted = true WHERE id = ?")
+@SQLRestriction("deleted = false")
 public class User extends BaseEntity {
 
     private String nickname;

--- a/src/main/java/com/zerozero/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/zerozero/user/domain/repository/UserRepository.java
@@ -11,5 +11,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByEmail(String email);
 
-    List<User> findAllByIdInAndDeleted(List<UUID> userIds, boolean deleted);
+    List<User> findAllByIdIn(List<UUID> userIds);
 }


### PR DESCRIPTION
## AS-IS
- 매번 조회할 때 마다 delete 조건 절을 추가하여 코드 복잡성 증가.
- 삭제할 때도 cascade, orphanRemoval의 이점을 사용하지 못함.

## TO-BE
- @SQLDelete를 통해 엔티티 삭제 시, 자동으로 쿼리 실행
- @SQLRestriction 사용하여 기존의 delete 조건 절을 사용하지 않아도 됨.