### PR TITLE
FEAT: (#156) Store 엔티티에 이미지 정보를 fetch join으로 함께 조회하는 쿼리를 추가한다

### DIFF
--- a/src/main/java/com/zerozero/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/zerozero/store/domain/repository/StoreRepository.java
@@ -27,7 +27,19 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
             """, nativeQuery = true)
     Optional<Integer> findStoreUserRank(@Param("userId") UUID userId);
 
+    @Query("""
+                SELECT s FROM Store s
+                LEFT JOIN FETCH s.images
+                WHERE s.id = :storeId
+            """)
+    Optional<Store> findByIdWithImages(@Param("storeId") UUID storeId);
+
     Store findByNameAndGeoLocation(String name, GeoLocation geoLocation);
 
-    List<Store> findAllByUserId(UUID userId);
+    @Query("""
+                SELECT s FROM Store s
+                LEFT JOIN FETCH s.images
+                WHERE s.userId = :userId
+            """)
+    List<Store> findAllByUserIdWithImages(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/zerozero/store/domain/service/ReadStoreInfoUseCase.java
+++ b/src/main/java/com/zerozero/store/domain/service/ReadStoreInfoUseCase.java
@@ -19,7 +19,7 @@ public class ReadStoreInfoUseCase {
     private final StoreRepository storeRepository;
 
     public StoreResponse execute(UUID storeId) {
-        Store store = storeRepository.findById(storeId).orElseThrow(() -> new StoreException(StoreErrorType.NOT_EXIST_STORE));
+        Store store = storeRepository.findByIdWithImages(storeId).orElseThrow(() -> new StoreException(StoreErrorType.NOT_EXIST_STORE));
         return StoreResponse.from(store);
     }
 

--- a/src/main/java/com/zerozero/store/domain/service/ReadUserStoresUseCase.java
+++ b/src/main/java/com/zerozero/store/domain/service/ReadUserStoresUseCase.java
@@ -18,7 +18,7 @@ public class ReadUserStoresUseCase {
     private final StoreRepository storeRepository;
 
     public List<StoreResponse> execute(User user) {
-        return storeRepository.findAllByUserId(user.getId())
+        return storeRepository.findAllByUserIdWithImages(user.getId())
                 .stream()
                 .map(StoreResponse::from)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## AS-IS
- 판매점 조회 시, 연관된 이미지 객체를 사용할 경우(지연 로딩) 이미지 조회 쿼리가 발생한다.
```sql
Hibernate: 
    select
        s1_0.id,
        s1_0.address,
        ...
    from
        store s1_0 

Hibernate: 
    select
        i1_0.store_id,
        i1_0.image_url 
    from
        store_images i1_0 
    where
        i1_0.store_id=?
```

## TO-BE
- 연관된 이미지와 관계 없이 하나의 쿼리로 가져온다.
```sql
Hibernate: 
    select
        s1_0.id,
        s1_0.address,
        ...
    from
        store s1_0 
    left join
        store_images i1_0 
            on s1_0.id=i1_0.store_id 
```