### PR TITLE
FEAT: (#158) 판매점 조회 시 캐싱을 적용한다

### DIFF
--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }

--- a/src/main/java/com/zerozero/configuration/CachingConfiguration.java
+++ b/src/main/java/com/zerozero/configuration/CachingConfiguration.java
@@ -1,0 +1,19 @@
+package com.zerozero.configuration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CachingConfiguration {
+
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager concurrentMapCacheManager = new ConcurrentMapCacheManager();
+        concurrentMapCacheManager.setAllowNullValues(false);
+        return concurrentMapCacheManager;
+    }
+}

--- a/src/main/java/com/zerozero/store/domain/service/ReadStoreInfoUseCase.java
+++ b/src/main/java/com/zerozero/store/domain/service/ReadStoreInfoUseCase.java
@@ -6,6 +6,7 @@ import com.zerozero.store.domain.response.StoreResponse;
 import com.zerozero.store.exception.StoreErrorType;
 import com.zerozero.store.exception.StoreException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ public class ReadStoreInfoUseCase {
 
     private final StoreRepository storeRepository;
 
+    @Cacheable(value = "stores", key = "#storeId")
     public StoreResponse execute(UUID storeId) {
         Store store = storeRepository.findByIdWithImages(storeId).orElseThrow(() -> new StoreException(StoreErrorType.NOT_EXIST_STORE));
         return StoreResponse.from(store);


### PR DESCRIPTION
## 도입 이유
- 판매점 조회 시, 판매점과 이에 포함된 리뷰를 조회하는 쿼리가 동작한다.
- 판매점은 1회 등록 후, 수정이나 삭제가 되지 않는다.
- 즉, 조회할 때마다 매번 같은 판매점 정보가 보여지는데 호출할 때마다 쿼리를 날려 조회하는 건 불필요한 DB I/O를 유발한다.

## TO-BE
- 스프링에서 제공하는 CacheManager를 사용하여 캐싱 처리.