### PR TITLE
FIX: (#160) 카카오에서 제공하는 장소 ID를 통해 판매점을 등록하도록 변경한다

### DIFF
--- a/src/main/java/com/zerozero/store/domain/model/Store.java
+++ b/src/main/java/com/zerozero/store/domain/model/Store.java
@@ -2,9 +2,9 @@ package com.zerozero.store.domain.model;
 
 import com.zerozero.core.domain.BaseEntity;
 import com.zerozero.image.domain.model.Image;
-import com.zerozero.store.domain.response.StoreSearchResponse;
 import com.zerozero.store.domain.value.Address;
 import com.zerozero.store.domain.value.GeoLocation;
+import com.zerozero.store.presentation.request.CreateStoreRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -53,17 +53,17 @@ public class Store extends BaseEntity {
 
     private UUID userId;
 
-    public static Store create(UUID userId, StoreSearchResponse store, List<String> images) {
+    public static Store create(UUID userId, CreateStoreRequest createStoreRequest) {
         return Store.builder()
-                .kakaoId(store.id())
-                .name(store.placeName())
-                .category(store.categoryName())
-                .phone(store.phone())
-                .address(Address.of(store.addressName(), store.roadAddressName()))
-                .geoLocation(GeoLocation.of(store.longitude(), store.latitude()))
+                .kakaoId(createStoreRequest.kakaoId())
+                .name(createStoreRequest.placeName())
+                .category(createStoreRequest.category())
+                .phone(createStoreRequest.phone())
+                .address(Address.of(createStoreRequest.address(), createStoreRequest.roadAddress()))
+                .geoLocation(GeoLocation.of(createStoreRequest.longitude(), createStoreRequest.latitude()))
                 .status(true)
-                .images(images.stream().map(Image::from).collect(Collectors.toList()))
-                .placeUrl(store.placeUrl())
+                .images(createStoreRequest.images().stream().map(Image::from).collect(Collectors.toList()))
+                .placeUrl(createStoreRequest.placeUrl())
                 .userId(userId)
                 .build();
     }

--- a/src/main/java/com/zerozero/store/domain/service/CreateStoreUseCase.java
+++ b/src/main/java/com/zerozero/store/domain/service/CreateStoreUseCase.java
@@ -3,9 +3,6 @@ package com.zerozero.store.domain.service;
 import com.zerozero.store.domain.event.StoreCreatedEvent;
 import com.zerozero.store.domain.model.Store;
 import com.zerozero.store.domain.repository.StoreRepository;
-import com.zerozero.store.domain.response.StoreSearchResponse;
-import com.zerozero.store.exception.StoreErrorType;
-import com.zerozero.store.exception.StoreException;
 import com.zerozero.store.presentation.request.CreateStoreRequest;
 import com.zerozero.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +10,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -23,22 +19,10 @@ public class CreateStoreUseCase {
 
     private final StoreRepository storeRepository;
 
-    private final StoreSearcher storeSearcher;
-
     private final ApplicationEventPublisher eventPublisher;
 
     public UUID execute(CreateStoreRequest createStoreRequest, User user) {
-        List<StoreSearchResponse> storeSearchResponses = storeSearcher.search(createStoreRequest.placeName());
-
-        StoreSearchResponse storeSearchResponse = storeSearchResponses.stream()
-                .filter(store ->
-                        createStoreRequest.placeName().equals(store.placeName()) &&
-                                createStoreRequest.longitude().equals(store.longitude()) &&
-                                createStoreRequest.latitude().equals(store.latitude()))
-                .findFirst()
-                .orElseThrow(() -> new StoreException(StoreErrorType.NOT_EXIST_STORE));
-
-        Store store = Store.create(user.getId(), storeSearchResponse, createStoreRequest.images());
+        Store store = Store.create(user.getId(), createStoreRequest);
         storeRepository.save(store);
 
         UUID storeId = store.getId();

--- a/src/main/java/com/zerozero/store/presentation/request/CreateStoreRequest.java
+++ b/src/main/java/com/zerozero/store/presentation/request/CreateStoreRequest.java
@@ -1,14 +1,35 @@
 package com.zerozero.store.presentation.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record CreateStoreRequest(
+        @NotNull(message = "판매점 카카오 ID는 필수 값입니다.")
+        @Schema(description = "카카오 ID", example = "25770215")
+        String kakaoId,
+
         @NotNull(message = "판매점 이름은 필수 값입니다.")
         @Schema(description = "판매점 이름", example = "꿉당")
         String placeName,
+
+        @NotNull(message = "판매점 카테고리는 필수 값입니다.")
+        @Schema(description = "판매점 카테고리", example = "음식점 > 한식 > 육류,고기")
+        String category,
+
+        @NotNull(message = "판매점 전화번호는 필수 값입니다.")
+        @Schema(description = "판매점 전화번호", example = "02-525-6692")
+        String phone,
+
+        @NotNull(message = "판매점 주소는 필수 값입니다.")
+        @Schema(description = "판매점 주소", example = "서울특별시 강남구 역삼동 123-4")
+        String address,
+
+        @NotNull(message = "판매점 도로명 주소는 필수 값입니다.")
+        @Schema(description = "판매점 도로명 주소", example = "서울특별시 강남구 테헤란로 123")
+        String roadAddress,
 
         @NotNull(message = "판매점 x좌표(경도)는 필수 값입니다.")
         @Schema(description = "판매점 x좌표(경도)", example = "127.01275515884753")
@@ -18,7 +39,11 @@ public record CreateStoreRequest(
         @Schema(description = "판매점 y좌표(위도)", example = "37.49206032952165")
         String latitude,
 
-        @NotNull(message = "판매점 사진은 필수 값입니다.")
+        @NotNull(message = "판매점 상세페이지 URL은 필수 값입니다.")
+        @Schema(description = "판매점 상세페이지 URL", example = "http://place.map.kakao.com/26338954")
+        String placeUrl,
+
+        @NotEmpty(message = "판매점 사진은 필수 값입니다.")
         @Schema(description = "판매점 업로드 이미지 URL 리스트",
                 example = "[\"https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/0cbf3b99-b0ba-4148-a891-d04cb71ae236-test.png\", \"https://s3.ap-northeast-2.amazonaws.com/zerozero-upload/images/store/another-image.png\"]")
         List<String> images) {


### PR DESCRIPTION
## AS-IS 
**판매점 등록 플로우**
1. 판매점 검색
2. 판매점 등록 (이때 서버에서 한번 더 판매점을 검색하여 데이터를 가지고 저장)

어차피 판매점 검색을 통해 데이터를 받아오는데 서버에서 또 호출하여 받아오는 것은 비효율적이라 생각함.

## TO-BE
- 판매점 등록 시, 판매점 검색에서 얻은 정보를 가지고 request body에 넣어서 저장.
- 불필요한 호출 제거